### PR TITLE
[FIX] Color Asset 네이밍 변경(#15)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHNavigationBarView.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHNavigationBarView.swift
@@ -74,7 +74,7 @@ final class LHNavigationBarView: UIView {
     }
 
     private func setStyle() {
-        self.backgroundColor = .black
+        self.backgroundColor = .designSystem(.background)
     }
 
     // MARK: - addsubView

--- a/LionHeart-iOS/LionHeart-iOS/Global/Utils/Palette.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Utils/Palette.swift
@@ -8,19 +8,19 @@
 import Foundation
 
 enum Palette: String {
-    case black
-    case white
-    case gray100
-    case gray200
-    case gray300
-    case gray400
-    case gray500
-    case gray600
-    case gray700
-    case gray800
-    case gray900
-    case gray1000
-    case lionRed
-    case componentLionRed
-    case background
+    case black = "Black"
+    case white = "White"
+    case gray100 = "Gray100"
+    case gray200 = "Gray200"
+    case gray300 = "Gray300"
+    case gray400 = "Gray400"
+    case gray500 = "Gray500"
+    case gray600 = "Gray600"
+    case gray700 = "Gray700"
+    case gray800 = "Gray800"
+    case gray900 = "Gray900"
+    case gray1000 = "Gray1000"
+    case lionRed = "LionRed"
+    case componentLionRed = "ComponentLionRed"
+    case background = "Background"
 }


### PR DESCRIPTION
## [#15] FIX : Color Asset 네이밍변경

## 🌱 작업한 내용
- Color Asset쪽 rawValue에 대소문자 구분이 안되어있어서 color변경이 안되는 문제를 해결했습니다
- 공용 navigation 배경색 designSystem color로 변경

## 🌱 PR Point
- Palette 파일수정
- LHNavigationBarView background컬러 변경

## 📮 관련 이슈

- Resolved: #15 
