### PR TITLE
[FEAT] CurriculumView TableView 구현 (#19)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		C0DF03962A5B8FB10037F740 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DF03952A5B8FB10037F740 /* Palette.swift */; };
 		C0DF03982A5B90790037F740 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DF03972A5B90790037F740 /* UIColor+.swift */; };
 		C0DF039A2A5B908E0037F740 /* CGColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DF03992A5B908E0037F740 /* CGColor+.swift */; };
+		F4490C072A5CEEA300A6D9D7 /* CurriculumDummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4490C062A5CEEA300A6D9D7 /* CurriculumDummyData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -193,6 +194,7 @@
 		C0DF03952A5B8FB10037F740 /* Palette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
 		C0DF03972A5B90790037F740 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		C0DF03992A5B908E0037F740 /* CGColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGColor+.swift"; sourceTree = "<group>"; };
+		F4490C062A5CEEA300A6D9D7 /* CurriculumDummyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumDummyData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -520,6 +522,7 @@
 		B598920F2A56B44200CE1FEB /* Curriculum */ = {
 			isa = PBXGroup;
 			children = (
+				F4490C052A5CEE8000A6D9D7 /* Model */,
 				B59892622A56B94D00CE1FEB /* Cells */,
 				B59892612A56B94B00CE1FEB /* Views */,
 				B59892602A56B94700CE1FEB /* ViewControllers */,
@@ -801,6 +804,14 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		F4490C052A5CEE8000A6D9D7 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				F4490C062A5CEEA300A6D9D7 /* CurriculumDummyData.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -973,6 +984,7 @@
 				B59892E52A5B109900CE1FEB /* ScreenUtils.swift in Sources */,
 				B532E8652A5529F100F0DB19 /* BaseResponse.swift in Sources */,
 				C0DF03452A5A9A910037F740 /* CurriculumTableViewCell.swift in Sources */,
+				F4490C072A5CEEA300A6D9D7 /* CurriculumDummyData.swift in Sources */,
 				B59892EC2A5B94E100CE1FEB /* UIApplication+.swift in Sources */,
 				C0DF035F2A5A9C330037F740 /* ArticleListByWeekViewController.swift in Sources */,
 				C0DF039A2A5B908E0037F740 /* CGColor+.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Application/SceneDelegate.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Application/SceneDelegate.swift
@@ -32,7 +32,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         /// 폰트등록
         Font.registerFonts()
         
-        let navigationController = UINavigationController(rootViewController: CurriculumViewController())
+        let navigationController = UINavigationController(rootViewController: TabBarViewController())
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }

--- a/LionHeart-iOS/LionHeart-iOS/Application/SceneDelegate.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Application/SceneDelegate.swift
@@ -32,7 +32,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         /// 폰트등록
         Font.registerFonts()
         
-        let navigationController = UINavigationController(rootViewController: TabBarViewController())
+        let navigationController = UINavigationController(rootViewController: CurriculumViewController())
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumTableViewCell.swift
@@ -12,9 +12,42 @@ import SnapKit
 
 final class CurriculumTableViewCell: UITableViewCell, TableViewCellRegisterDequeueProtocol {
     
-    var inputData: DummyModel? {
+    private enum Size {
+        static let widthRatio: CGFloat = 120 / 335
+    }
+    
+    private let week: UILabel = {
+        let label = UILabel()
+        label.font = .pretendard(.body2M)
+        label.textColor = .designSystem(.gray500)
+        return label
+    }()
+    private let weekTitle: UILabel = {
+        let label = UILabel()
+        label.font = .pretendard(.body2R)
+        label.textColor = .designSystem(.gray100)
+        return label
+    }()
+    private let contextImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .red
+        return imageView
+    }()
+    private let contextText: UILabel = {
+        let label = UILabel()
+        label.font = .pretendard(.body3R)
+        label.textColor = .designSystem(.gray500)
+        label.numberOfLines = 0
+       return label
+    }()
+    
+    var inputData: CurriculumDummyData? {
         didSet {
-            /// action
+            self.week.text = inputData?.curriculumWeek
+            self.weekTitle.text = inputData?.curriculumWeekTitle
+            self.contextImage.image = inputData?.curriculumImage
+            self.contextText.text = inputData?.curriculumText
+            
         }
     }
 
@@ -48,11 +81,32 @@ private extension CurriculumTableViewCell {
     }
     
     func setHierarchy() {
-        
+        contentView.addSubviews(week,weekTitle,contextImage,contextText)
     }
     
     func setLayout() {
+        week.snp.makeConstraints{
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalToSuperview().inset(17)
+        }
         
+        weekTitle.snp.makeConstraints{
+            $0.leading.equalTo(week.snp.trailing).offset(8)
+            $0.centerY.equalTo(week)
+        }
+        
+        contextImage.snp.makeConstraints{
+            $0.top.equalTo(weekTitle.snp.bottom).offset(15)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(Constant.Screen.width - 40)
+            $0.height.equalTo(contextImage.snp.width).multipliedBy(Size.widthRatio)
+        }
+        
+        contextText.snp.makeConstraints{
+            $0.top.equalTo(contextImage.snp.bottom).offset(12)
+            $0.bottom.equalToSuperview()
+            $0.centerX.equalToSuperview()
+        }
     }
     
     func setAddTarget() {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumTableViewCell.swift
@@ -16,24 +16,24 @@ final class CurriculumTableViewCell: UITableViewCell, TableViewCellRegisterDeque
         static let widthRatio: CGFloat = 120 / 335
     }
     
-    private let week: UILabel = {
+    private let weekLabel: UILabel = {
         let label = UILabel()
         label.font = .pretendard(.body2M)
         label.textColor = .designSystem(.gray500)
         return label
     }()
-    private let weekTitle: UILabel = {
+    private let weekTitleLabel: UILabel = {
         let label = UILabel()
         label.font = .pretendard(.body2R)
         label.textColor = .designSystem(.gray100)
         return label
     }()
-    private let contextImage: UIImageView = {
+    private let contextImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .red
         return imageView
     }()
-    private let contextText: UILabel = {
+    private let contextTextLabel: UILabel = {
         let label = UILabel()
         label.font = .pretendard(.body3R)
         label.textColor = .designSystem(.gray500)
@@ -43,10 +43,10 @@ final class CurriculumTableViewCell: UITableViewCell, TableViewCellRegisterDeque
     
     var inputData: CurriculumDummyData? {
         didSet {
-            self.week.text = inputData?.curriculumWeek
-            self.weekTitle.text = inputData?.curriculumWeekTitle
-            self.contextImage.image = inputData?.curriculumImage
-            self.contextText.text = inputData?.curriculumText
+            self.weekLabel.text = inputData?.curriculumWeek
+            self.weekTitleLabel.text = inputData?.curriculumWeekTitle
+            self.contextImageView.image = inputData?.curriculumImage
+            self.contextTextLabel.text = inputData?.curriculumText
             
         }
     }
@@ -81,29 +81,29 @@ private extension CurriculumTableViewCell {
     }
     
     func setHierarchy() {
-        contentView.addSubviews(week,weekTitle,contextImage,contextText)
+        contentView.addSubviews(weekLabel,weekTitleLabel,contextImageView,contextTextLabel)
     }
     
     func setLayout() {
-        week.snp.makeConstraints{
+        weekLabel.snp.makeConstraints{
             $0.leading.equalToSuperview().inset(20)
             $0.top.equalToSuperview().inset(17)
         }
         
-        weekTitle.snp.makeConstraints{
-            $0.leading.equalTo(week.snp.trailing).offset(8)
-            $0.centerY.equalTo(week)
+        weekTitleLabel.snp.makeConstraints{
+            $0.leading.equalTo(weekLabel.snp.trailing).offset(8)
+            $0.centerY.equalTo(weekLabel)
         }
         
-        contextImage.snp.makeConstraints{
-            $0.top.equalTo(weekTitle.snp.bottom).offset(15)
+        contextImageView.snp.makeConstraints{
+            $0.top.equalTo(weekTitleLabel.snp.bottom).offset(15)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(Constant.Screen.width - 40)
-            $0.height.equalTo(contextImage.snp.width).multipliedBy(Size.widthRatio)
+            $0.height.equalTo(contextImageView.snp.width).multipliedBy(Size.widthRatio)
         }
         
-        contextText.snp.makeConstraints{
-            $0.top.equalTo(contextImage.snp.bottom).offset(12)
+        contextTextLabel.snp.makeConstraints{
+            $0.top.equalTo(contextImageView.snp.bottom).offset(12)
             $0.bottom.equalToSuperview()
             $0.centerX.equalToSuperview()
         }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Model/CurriculumDummyData.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Model/CurriculumDummyData.swift
@@ -16,26 +16,27 @@ struct CurriculumMonthData: AppData{
 struct CurriculumDummyData: AppData {
     let curriculumWeek: String
     let curriculumWeekTitle: String
-    let curriculumImage: UIImageView
+    let curriculumImage: UIImage
     let curriculumText: String
 }
 extension CurriculumMonthData {
     static func dummy() -> [CurriculumMonthData] {
-        return [CurriculumMonthData(month: "1개월", weekDatas: [
-            .init(curriculumWeek: "1주차", curriculumWeekTitle: "1주차 제목", curriculumImage: UIImageView(), curriculumText: "1주차 내용"),
-            .init(curriculumWeek: "2개월", curriculumWeekTitle: "2주차 제목", curriculumImage: UIImageView(), curriculumText: "2주차 내용")
+        return [
+            CurriculumMonthData(month: "1개월", weekDatas: [
+            .init(curriculumWeek: "1주차", curriculumWeekTitle: "1주차 제목", curriculumImage: UIImage(), curriculumText: "1주차 내용"),
+            .init(curriculumWeek: "2주차", curriculumWeekTitle: "2주차 제목", curriculumImage: UIImage(), curriculumText: "2주차 내용")
         ]),
-                .init(month: "2개월", weekDatas: [
-                    .init(curriculumWeek: "3주차", curriculumWeekTitle: "3주차 제목", curriculumImage: UIImageView(), curriculumText: "3주차 내용"),
-                    .init(curriculumWeek: "4주차", curriculumWeekTitle: "4주차 제목", curriculumImage: UIImageView(), curriculumText: "4주차 내용")
+            CurriculumMonthData(month: "2개월", weekDatas: [
+                    .init(curriculumWeek: "3주차", curriculumWeekTitle: "3주차 제목", curriculumImage: UIImage(), curriculumText: "3주차 내용"),
+                    .init(curriculumWeek: "4주차", curriculumWeekTitle: "4주차 제목", curriculumImage: UIImage(), curriculumText: "4주차 내용")
                 ]),
                 .init(month: "3개월", weekDatas: [
-                    .init(curriculumWeek: "5주차", curriculumWeekTitle: "5주차 제목", curriculumImage: UIImageView(), curriculumText: "5주차 내용"),
-                    .init(curriculumWeek: "6주차", curriculumWeekTitle: "6주차 제목", curriculumImage: UIImageView(), curriculumText: "6주차 내용")
+                    .init(curriculumWeek: "5주차", curriculumWeekTitle: "5주차 제목", curriculumImage: UIImage(), curriculumText: "5주차 내용"),
+                    .init(curriculumWeek: "6주차", curriculumWeekTitle: "6주차 제목", curriculumImage: UIImage(), curriculumText: "6주차 내용")
                 ]),
                 .init(month: "4개월", weekDatas: [
-                    .init(curriculumWeek: "7주차", curriculumWeekTitle: "7주차 제목", curriculumImage: UIImageView(), curriculumText: "7주차 내용"),
-                    .init(curriculumWeek: "8주차", curriculumWeekTitle: "8주차 제목", curriculumImage: UIImageView(), curriculumText: "8주차 내용")
+                    .init(curriculumWeek: "7주차", curriculumWeekTitle: "7주차 제목", curriculumImage: UIImage(), curriculumText: "7주차 내용"),
+                    .init(curriculumWeek: "8주차", curriculumWeekTitle: "8주차 제목", curriculumImage: UIImage(), curriculumText: "8주차 내용")
                 ])
         ]
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Model/CurriculumDummyData.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Model/CurriculumDummyData.swift
@@ -1,0 +1,44 @@
+//
+//  CurriculumDummyData.swift
+//  LionHeart-iOS
+//
+//  Created by 곽성준 on 2023/07/11.
+//
+
+import UIKit
+
+
+struct CurriculumMonthData: AppData{
+    let month: String
+    let weekDatas: [CurriculumDummyData]
+}
+
+struct CurriculumDummyData: AppData {
+    let curriculumWeek: String
+    let curriculumWeekTitle: String
+    let curriculumImage: UIImageView
+    let curriculumText: String
+}
+extension CurriculumMonthData {
+    static func dummy() -> [CurriculumMonthData] {
+        return [CurriculumMonthData(month: "1개월", weekDatas: [
+            .init(curriculumWeek: "1주차", curriculumWeekTitle: "1주차 제목", curriculumImage: UIImageView(), curriculumText: "1주차 내용"),
+            .init(curriculumWeek: "2개월", curriculumWeekTitle: "2주차 제목", curriculumImage: UIImageView(), curriculumText: "2주차 내용")
+        ]),
+                .init(month: "2개월", weekDatas: [
+                    .init(curriculumWeek: "3주차", curriculumWeekTitle: "3주차 제목", curriculumImage: UIImageView(), curriculumText: "3주차 내용"),
+                    .init(curriculumWeek: "4주차", curriculumWeekTitle: "4주차 제목", curriculumImage: UIImageView(), curriculumText: "4주차 내용")
+                ]),
+                .init(month: "3개월", weekDatas: [
+                    .init(curriculumWeek: "5주차", curriculumWeekTitle: "5주차 제목", curriculumImage: UIImageView(), curriculumText: "5주차 내용"),
+                    .init(curriculumWeek: "6주차", curriculumWeekTitle: "6주차 제목", curriculumImage: UIImageView(), curriculumText: "6주차 내용")
+                ]),
+                .init(month: "4개월", weekDatas: [
+                    .init(curriculumWeek: "7주차", curriculumWeekTitle: "7주차 제목", curriculumImage: UIImageView(), curriculumText: "7주차 내용"),
+                    .init(curriculumWeek: "8주차", curriculumWeekTitle: "8주차 제목", curriculumImage: UIImageView(), curriculumText: "8주차 내용")
+                ])
+        ]
+    }
+}
+
+

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
@@ -37,7 +37,9 @@ final class CurriculumViewController: UIViewController{
         
         // MARK: - delegate설정
         setDelegate()
-
+        
+        // MARK: - tableView Register설정
+        setTableView()
     }
 }
 
@@ -64,6 +66,9 @@ private extension CurriculumViewController {
     func setDelegate() {
         curriculumTableView.dataSource = self
         curriculumTableView.delegate = self
+    }
+    
+    func setTableView(){
         CurriculumTableViewCell.register(to: curriculumTableView)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
@@ -10,8 +10,16 @@ import UIKit
 
 import SnapKit
 
-final class CurriculumViewController: UIViewController {
+final class CurriculumViewController: UIViewController{
     
+    private let curriculumTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.estimatedRowHeight = 200
+        tableView.rowHeight = UITableView.automaticDimension
+        return tableView
+    }()
+    
+    private let curriculumViewDatas = CurriculumMonthData.dummy()
 
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,11 +47,14 @@ private extension CurriculumViewController {
     }
     
     func setHierarchy() {
-        
+        view.addSubviews(curriculumTableView)
+
     }
     
     func setLayout() {
-        
+        curriculumTableView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
     }
     
     func setAddTarget() {
@@ -51,6 +62,28 @@ private extension CurriculumViewController {
     }
     
     func setDelegate() {
-        
+        curriculumTableView.dataSource = self
+        curriculumTableView.delegate = self
+        CurriculumTableViewCell.register(to: curriculumTableView)
     }
 }
+
+extension CurriculumViewController: UITableViewDataSource{
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return curriculumViewDatas[section].weekDatas.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = CurriculumTableViewCell.dequeueReusableCell(to: tableView)
+        cell.inputData = curriculumViewDatas[indexPath.section].weekDatas[indexPath.row]
+        cell.selectionStyle = .none
+        return cell
+    }
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return curriculumViewDatas.count
+    }
+    
+}
+
+extension CurriculumViewController: UITableViewDelegate{}


### PR DESCRIPTION
## [#100] FEAT : 로그인 구현

## 🌱 작업한 내용

- 예시 더미데이터 작성
- 테이블뷰 구현

## 🌱 PR Point

- 예시 더미데이터를 만들어 테이블뷰에 뿌려서 레이아웃을 잡아봤습니다.

<img width="400" alt="스크린샷 2023-07-11 오후 3 28 13" src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/70939232/70c1e489-7e92-48bc-858a-cfbcab03df01">

multipliedBy 여기 안에서는 연산이 안되기 때문에(왜 안되는지는 몰라요..)


<img width="400" alt="스크린샷 2023-07-11 오후 3 28 18" src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/70939232/028807dc-808a-43ed-ae74-55a8d98a9659">


위 사진과 같이 따로 이넘으로 연산과정을 뺴주었습니다.

## 📸 스크린샷
1. 아이폰14프로





|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 커리큘럼 테이블뷰 |<img src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/70939232/5bb44e92-aae9-41ce-97fe-cd336466b98c" width="400"/>  |


3. 아이폰SE




|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 커리큘럼 테이블뷰 | <img src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/70939232/31d5a055-6e70-4d89-8334-62149a220562" width="400"/> |

## 📮 관련 이슈

- Resolved: #19
