### PR TITLE
[FEAT] 로딩뷰 구현 (#91)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		B520EA6C2A670C010027356E /* progressbar_2m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA632A670C010027356E /* progressbar_2m.json */; };
 		B520EA6D2A670C010027356E /* progressbar_3m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA642A670C010027356E /* progressbar_3m.json */; };
 		B520EA6E2A670C010027356E /* progressbar_5m.json in Resources */ = {isa = PBXBuildFile; fileRef = B520EA652A670C010027356E /* progressbar_5m.json */; };
-		B520EA6F2A670C300027356E /* BookmarkDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8980C12A5FD6AF00746C58 /* BookmarkDetailCollectionViewCell.swift */; };
 		B532E8322A5525C600F0DB19 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8312A5525C600F0DB19 /* AppDelegate.swift */; };
 		B532E8342A5525C600F0DB19 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8332A5525C600F0DB19 /* SceneDelegate.swift */; };
 		B532E8362A5525C600F0DB19 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8352A5525C600F0DB19 /* ViewController.swift */; };
@@ -46,6 +45,7 @@
 		B532E8652A5529F100F0DB19 /* BaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E8642A5529F100F0DB19 /* BaseResponse.swift */; };
 		B532E86C2A5564DD00F0DB19 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532E86B2A5564DD00F0DB19 /* Encodable+.swift */; };
 		B53881B62A6649D6002D166E /* motion_logo_final.json in Resources */ = {isa = PBXBuildFile; fileRef = B53881B52A6649D6002D166E /* motion_logo_final.json */; };
+		B53BA2022A68717B006F9BFB /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BA2012A68717B006F9BFB /* LoadingIndicator.swift */; };
 		B57BEB612A60E97100D1727C /* NetworkErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57BEB602A60E97100D1727C /* NetworkErrorCode.swift */; };
 		B57BEB632A612DA100D1727C /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57BEB622A612DA100D1727C /* UserDefaultsManager.swift */; };
 		B57BEB652A6134B800D1727C /* setRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57BEB642A6134B800D1727C /* setRootViewController.swift */; };
@@ -176,15 +176,6 @@
 		D3BA0B712A5CFA2300B6361F /* ArticleCategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA0B702A5CFA2300B6361F /* ArticleCategoryCollectionViewCell.swift */; };
 		D3BA0B742A5CFA7B00B6361F /* ArticleCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA0B732A5CFA7B00B6361F /* ArticleCategoryModel.swift */; };
 		F41A97A12A5D4F2500DFF9F3 /* CurriculumTableViewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41A97A02A5D4F2500DFF9F3 /* CurriculumTableViewHeaderView.swift */; };
-		F43355622A67E40400016CAB /* progressbar_9m.json in Resources */ = {isa = PBXBuildFile; fileRef = F43355592A67E40400016CAB /* progressbar_9m.json */; };
-		F43355632A67E40400016CAB /* progressbar_8m.json in Resources */ = {isa = PBXBuildFile; fileRef = F433555A2A67E40400016CAB /* progressbar_8m.json */; };
-		F43355642A67E40400016CAB /* progressbar_6m.json in Resources */ = {isa = PBXBuildFile; fileRef = F433555B2A67E40400016CAB /* progressbar_6m.json */; };
-		F43355652A67E40400016CAB /* progressbar_7m.json in Resources */ = {isa = PBXBuildFile; fileRef = F433555C2A67E40400016CAB /* progressbar_7m.json */; };
-		F43355662A67E40400016CAB /* progressbar_5m.json in Resources */ = {isa = PBXBuildFile; fileRef = F433555D2A67E40400016CAB /* progressbar_5m.json */; };
-		F43355672A67E40400016CAB /* progressbar_4m.json in Resources */ = {isa = PBXBuildFile; fileRef = F433555E2A67E40400016CAB /* progressbar_4m.json */; };
-		F43355682A67E40400016CAB /* progressbar_2m.json in Resources */ = {isa = PBXBuildFile; fileRef = F433555F2A67E40400016CAB /* progressbar_2m.json */; };
-		F43355692A67E40400016CAB /* progressbar_10m.json in Resources */ = {isa = PBXBuildFile; fileRef = F43355602A67E40400016CAB /* progressbar_10m.json */; };
-		F433556A2A67E40400016CAB /* progressbar_3m.json in Resources */ = {isa = PBXBuildFile; fileRef = F43355612A67E40400016CAB /* progressbar_3m.json */; };
 		F435E04C2A5DA6A40098E691 /* CurriculumUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435E04B2A5DA6A40098E691 /* CurriculumUserInfoView.swift */; };
 		F435E0542A5E67BF0098E691 /* NSObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435E0532A5E67BF0098E691 /* NSObject+.swift */; };
 		F4490C072A5CEEA300A6D9D7 /* CurriculumDummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4490C062A5CEEA300A6D9D7 /* CurriculumDummyData.swift */; };
@@ -268,6 +259,7 @@
 		B532E8692A552BA500F0DB19 /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 		B532E86B2A5564DD00F0DB19 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		B53881B52A6649D6002D166E /* motion_logo_final.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = motion_logo_final.json; sourceTree = "<group>"; };
+		B53BA2012A68717B006F9BFB /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
 		B57BEB602A60E97100D1727C /* NetworkErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorCode.swift; sourceTree = "<group>"; };
 		B57BEB622A612DA100D1727C /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		B57BEB642A6134B800D1727C /* setRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = setRootViewController.swift; sourceTree = "<group>"; };
@@ -383,15 +375,11 @@
 		D3BA0B702A5CFA2300B6361F /* ArticleCategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		D3BA0B732A5CFA7B00B6361F /* ArticleCategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCategoryModel.swift; sourceTree = "<group>"; };
 		F41A97A02A5D4F2500DFF9F3 /* CurriculumTableViewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumTableViewHeaderView.swift; sourceTree = "<group>"; };
-		F43355592A67E40400016CAB /* progressbar_9m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_9m.json; sourceTree = "<group>"; };
-		F433555A2A67E40400016CAB /* progressbar_8m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_8m.json; sourceTree = "<group>"; };
 		F433555B2A67E40400016CAB /* progressbar_6m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_6m.json; sourceTree = "<group>"; };
 		F433555C2A67E40400016CAB /* progressbar_7m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_7m.json; sourceTree = "<group>"; };
 		F433555D2A67E40400016CAB /* progressbar_5m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_5m.json; sourceTree = "<group>"; };
-		F433555E2A67E40400016CAB /* progressbar_4m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_4m.json; sourceTree = "<group>"; };
 		F433555F2A67E40400016CAB /* progressbar_2m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_2m.json; sourceTree = "<group>"; };
 		F43355602A67E40400016CAB /* progressbar_10m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_10m.json; sourceTree = "<group>"; };
-		F43355612A67E40400016CAB /* progressbar_3m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_3m.json; sourceTree = "<group>"; };
 		F435E04B2A5DA6A40098E691 /* CurriculumUserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumUserInfoView.swift; sourceTree = "<group>"; };
 		F435E0532A5E67BF0098E691 /* NSObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+.swift"; sourceTree = "<group>"; };
 		F4490C062A5CEEA300A6D9D7 /* CurriculumDummyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriculumDummyData.swift; sourceTree = "<group>"; };
@@ -671,6 +659,7 @@
 				B59892ED2A5B9AF300CE1FEB /* NavigationBarLayoutManager.swift */,
 				B57BEB622A612DA100D1727C /* UserDefaultsManager.swift */,
 				B57BEB642A6134B800D1727C /* setRootViewController.swift */,
+				B53BA2012A68717B006F9BFB /* LoadingIndicator.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1186,6 +1175,11 @@
 				4AD6AE072A66F84C00A3D745 /* progressbar_4m.json */,
 				C0F62FBE2A67CDB60003ADFA /* progressbar_5m.json */,
 				4AD6AE032A66F83E00A3D745 /* progressbar_2m.json */,
+				F433555C2A67E40400016CAB /* progressbar_7m.json */,
+				F43355602A67E40400016CAB /* progressbar_10m.json */,
+				F433555F2A67E40400016CAB /* progressbar_2m.json */,
+				F433555D2A67E40400016CAB /* progressbar_5m.json */,
+				F433555B2A67E40400016CAB /* progressbar_6m.json */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1465,11 +1459,6 @@
 				B598930B2A5BED0F00CE1FEB /* Pretendard-Medium.ttf in Resources */,
 				B520EA672A670C010027356E /* progressbar_4m.json in Resources */,
 				B532E83E2A5525C700F0DB19 /* LaunchScreen.storyboard in Resources */,
-				F43355652A67E40400016CAB /* progressbar_7m.json in Resources */,
-				F43355692A67E40400016CAB /* progressbar_10m.json in Resources */,
-				F43355682A67E40400016CAB /* progressbar_2m.json in Resources */,
-				F43355662A67E40400016CAB /* progressbar_5m.json in Resources */,
-				F43355642A67E40400016CAB /* progressbar_6m.json in Resources */,
 				B598930C2A5BED0F00CE1FEB /* Pretendard-Regular.ttf in Resources */,
 				B59892832A56C93400CE1FEB /* GoogleService-Info.plist in Resources */,
 				B53881B62A6649D6002D166E /* motion_logo_final.json in Resources */,
@@ -1601,6 +1590,7 @@
 				F4DB30B02A611C9700413EB9 /* CurriculumListByWeekData.swift in Sources */,
 				C0DF034D2A5A9B8D0037F740 /* (null) in Sources */,
 				C09A33222A62D46300B40770 /* LHToast.swift in Sources */,
+				B53BA2022A68717B006F9BFB /* LoadingIndicator.swift in Sources */,
 				C06E381B2A65346700B00600 /* UserDefaultToken.swift in Sources */,
 				B5C6A2B82A5DDDFD0021BE5E /* EditorTableViewCell.swift in Sources */,
 				C0F029C72A5EFB9D00E0D185 /* LHProgressView.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Global/Utils/LoadingIndicator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Utils/LoadingIndicator.swift
@@ -13,19 +13,15 @@ final class LoadingIndicator {
         DispatchQueue.main.async {
             guard let window = UIApplication.keyWindow else { return }
 
-            let loadingIndicatorView: UIActivityIndicatorView
-            if let existedView = window.subviews.first(where: { $0 is UIActivityIndicatorView }) as? UIActivityIndicatorView {
-                loadingIndicatorView = existedView
-            } else {
-                loadingIndicatorView = UIActivityIndicatorView(style: .large)
-                loadingIndicatorView.color = .designSystem(.lionRed)
-                loadingIndicatorView.backgroundColor = .designSystem(.black)
-                loadingIndicatorView.frame = window.frame
-                window.addSubview(loadingIndicatorView)
-            }
+            let loadingIndicatorView = UIActivityIndicatorView(style: .large)
+            loadingIndicatorView.color = .designSystem(.lionRed)
+            loadingIndicatorView.backgroundColor = .designSystem(.black)
+
+            loadingIndicatorView.frame = window.frame
+            window.addSubview(loadingIndicatorView)
+
             loadingIndicatorView.startAnimating()
         }
-
     }
 
     static func hideLoading() {

--- a/LionHeart-iOS/LionHeart-iOS/Global/Utils/LoadingIndicator.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Utils/LoadingIndicator.swift
@@ -1,0 +1,42 @@
+//
+//  LoadingIndicator.swift
+//  LionHeart-iOS
+//
+//  Created by 김민재 on 2023/07/20.
+//
+
+import UIKit
+
+
+final class LoadingIndicator {
+    static func showLoading() {
+        DispatchQueue.main.async {
+            guard let window = UIApplication.keyWindow else { return }
+
+            let loadingIndicatorView: UIActivityIndicatorView
+            if let existedView = window.subviews.first(where: { $0 is UIActivityIndicatorView }) as? UIActivityIndicatorView {
+                loadingIndicatorView = existedView
+            } else {
+                loadingIndicatorView = UIActivityIndicatorView(style: .large)
+                loadingIndicatorView.color = .designSystem(.lionRed)
+                loadingIndicatorView.backgroundColor = .designSystem(.black)
+                loadingIndicatorView.frame = window.frame
+                window.addSubview(loadingIndicatorView)
+            }
+            loadingIndicatorView.startAnimating()
+        }
+
+    }
+
+    static func hideLoading() {
+        DispatchQueue.main.async {
+            let scenes = UIApplication.shared.connectedScenes
+            let windowScene = scenes.first as? UIWindowScene
+            guard let window = windowScene?.windows.last else { return }
+            window.subviews
+                .filter { $0 is UIActivityIndicatorView }
+                .forEach { $0.removeFromSuperview() }
+        }
+
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -52,6 +52,7 @@ final class ArticleDetailViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        LoadingIndicator.showLoading()
         getArticleDetail()
     }
     
@@ -69,6 +70,7 @@ extension ArticleDetailViewController {
         Task {
             do {
                 self.articleDatas = try await ArticleService.shared.getArticleDetail(articleId: 0)
+                LoadingIndicator.hideLoading()
             } catch {
                 guard let error = error as? NetworkError else { return }
                 handleError(error)
@@ -160,9 +162,9 @@ extension ArticleDetailViewController: UITableViewDataSource {
             let cell = ThumnailTableViewCell.dequeueReusableCell(to: articleTableView)
             cell.inputData = thumbnailModel
             cell.selectionStyle = .none
-            cell.bookmarkButtonDidTap = {
-                // TODO: Network POST 북마크
-            }
+//            cell.bookmarkButtonDidTap = {
+//                // TODO: Network POST 북마크
+//            }
             return cell
         case .articleTitle(let titleModel):
             let cell = TitleTableViewCell.dequeueReusableCell(to: articleTableView)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
@@ -35,10 +35,11 @@ final class BookmarkViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        LoadingIndicator.showLoading()
         Task {
             do {
                 self.bookmarkAppData = try await BookmarkService.shared.getBookmark()
+                LoadingIndicator.hideLoading()
                 bookmarkCollectionView.reloadData()
             } catch {
                 guard let error = error as? NetworkError else { return }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
@@ -40,7 +40,6 @@ final class TodayViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        LoadingIndicator.showLoading()
         getInquireTodayArticle()
     }
 }
@@ -75,7 +74,6 @@ extension TodayViewController {
                 titleLabel.title = responseArticle.articleTitle
                 mainArticleView.data = responseArticle
                 todayArticleID = responseArticle.aticleID
-                LoadingIndicator.hideLoading()
             } catch {
                 guard let error = error as? NetworkError else { return }
                 handleError(error)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
@@ -40,6 +40,7 @@ final class TodayViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        LoadingIndicator.showLoading()
         getInquireTodayArticle()
     }
 }
@@ -74,6 +75,7 @@ extension TodayViewController {
                 titleLabel.title = responseArticle.articleTitle
                 mainArticleView.data = responseArticle
                 todayArticleID = responseArticle.aticleID
+                LoadingIndicator.hideLoading()
             } catch {
                 guard let error = error as? NetworkError else { return }
                 handleError(error)

--- a/LionHeart-iOS/LionHeart-iOS/Settings/Info.plist
+++ b/LionHeart-iOS/LionHeart-iOS/Settings/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>


### PR DESCRIPTION
## [#91] FEAT : 로딩뷰 구현

## 🌱 작업한 내용
- 네트워크 통신이 미처 끝나지 않은 상태에서 화면전환이 이루어지게 되면 통신 결과가 화면에 뒤늦게 반영되면서 사용자 경험을 저하시킬 수 있습니다.
- 따라서 네트워크 통신을 하는 동안의 지연시간을 위해 Loading Indicator View를 추가하였습니다.

### 구현
### showLoading
```swift
final class LoadingIndicator {
    static func showLoading() {
        DispatchQueue.main.async {
            guard let window = UIApplication.keyWindow else { return }

            let loadingIndicatorView = UIActivityIndicatorView(style: .large)
            loadingIndicatorView.color = .designSystem(.lionRed)
            loadingIndicatorView.backgroundColor = .designSystem(.black)

            loadingIndicatorView.frame = window.frame
            window.addSubview(loadingIndicatorView)

            loadingIndicatorView.startAnimating()
        }
    }
```
- 최상단 window를 가져와서 화면을 가득채운 IndicatorView를 만들어서 addSubView후에 indicator를 start합니다.

### hideLoading
```swift
static func hideLoading() {
        DispatchQueue.main.async {
            let scenes = UIApplication.shared.connectedScenes
            let windowScene = scenes.first as? UIWindowScene
            guard let window = windowScene?.windows.last else { return }
            window.subviews
                .filter { $0 is UIActivityIndicatorView }
                .forEach { $0.removeFromSuperview() }
        }
    }
```
- window의 마지막 subview가 UIActivityIndicatorView일 때 removeFromSuperView를 통해서 삭제해서 로딩을 hide시켜줍니다.

### 사용법
```swift
/// ViewController.swift
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    LoadingIndicator.showLoading()
    getArticleDetail()
}
```
- viewWillAppear에서 GET API를 호출하기 이전에 `LoadingIndicator.showLoading()`메서드를 호출합니다.
```swift
func getArticleDetail() {
    Task {
        do {
            self.articleDatas = try await ArticleService.shared.getArticleDetail(articleId: 0)
            LoadingIndicator.hideLoading()
        } catch {
            guard let error = error as? NetworkError else { return }
            handleError(error)
        }
    }
}
```
- API를 호출하고 나온 이후에 `LoadingIndicator.hideLoading()`메서드를 호출합니다.


## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 로딩뷰 | <img src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/60292150/0857015c-e220-4a0b-b557-2755df74890c" width="300"/> |



## 📮 관련 이슈

- Resolved: #91 
