### PR TITLE
[FIX] Query String JSON Decoding Error hotfix (#96)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Network/Base/NetworkRequest.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/Base/NetworkRequest.swift
@@ -10,18 +10,29 @@ import Foundation
 struct NetworkRequest {
     let path: String
     let httpMethod: HttpMethod
+    let parameter: Request?
     let body: Data?
     let header: [String: String]?
 
-    init(path: String, httpMethod: HttpMethod, body: Data? = nil, header: [String : String]? = nil) {
+    init(path: String, httpMethod: HttpMethod, parameter: Request? = nil, body: Data? = nil, header: [String : String]? = nil) {
         self.path = path
         self.httpMethod = httpMethod
+        self.parameter = parameter
         self.body = body
         self.header = header
     }
 
     func makeURLRequest(isLogined: Bool) throws -> URLRequest {
-        let urlComponents = URLComponents(string: Config.baseURL)
+        var urlComponents = URLComponents(string: Config.baseURL)
+
+        if let query = self.parameter {
+            let queries = query.toDictionary()
+            let queryItemArray = queries.map {
+                return URLQueryItem(name: $0.key, value: "\($0.value)")
+            }
+            urlComponents?.queryItems = queryItemArray
+        }
+
         guard let urlRequestURL = urlComponents?.url?.appendingPathComponent(self.path) else {
             throw NetworkError.urlEncodingError
         }

--- a/LionHeart-iOS/LionHeart-iOS/Network/Base/NetworkRequest.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/Base/NetworkRequest.swift
@@ -10,14 +10,14 @@ import Foundation
 struct NetworkRequest {
     let path: String
     let httpMethod: HttpMethod
-    let parameter: Request?
+    let query: Request?
     let body: Data?
     let header: [String: String]?
 
-    init(path: String, httpMethod: HttpMethod, parameter: Request? = nil, body: Data? = nil, header: [String : String]? = nil) {
+    init(path: String, httpMethod: HttpMethod, query: Request? = nil, body: Data? = nil, header: [String : String]? = nil) {
         self.path = path
         self.httpMethod = httpMethod
-        self.parameter = parameter
+        self.query = query
         self.body = body
         self.header = header
     }
@@ -25,7 +25,7 @@ struct NetworkRequest {
     func makeURLRequest(isLogined: Bool) throws -> URLRequest {
         var urlComponents = URLComponents(string: Config.baseURL)
 
-        if let query = self.parameter {
+        if let query = self.query {
             let queries = query.toDictionary()
             let queryItemArray = queries.map {
                 return URLQueryItem(name: $0.key, value: "\($0.value)")


### PR DESCRIPTION
## [#96] [FIX] Query String JSON Decoding Error hotfix

## 🌱 작업한 내용
<img width="1431" alt="image" src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/60292150/ce5c0543-d7dc-4b5a-940f-574feeeb04de">

> http://3.34.174.158/api/v1/article?category=BUDGET
- 쿼리스트링으로 위와 같이 요청을 보내야하는 API.

```swift
func getArticleListByCategory(categoryString: String) async throws -> [ArticleDataByWeek] {
        let urlRequest = try NetworkRequest(path: "/v1/article?category=\(categoryString)", httpMethod: .get).makeURLRequest(isLogined: true)
```
따라서 처음에 categoryString의 문자열만 받아서 문자열 보간법으로 위와 같이 넣어주었습니다. 하지만 Data는 가져와지는데 이후 JSONDecoding하는 과정에서 decode 에러가 계속해서 떴고, 처음에는 Data가 잘가져와지기에 무언가 DTO구조체 정의하는 부분에서 에러가 있었다고 생각해 해당 부분을 서버와 계속해서 확인하느라 굉장히 오랜시간이 걸렸고 결국 아무 문제가 없다는 것을 알 수 있었습니다.

**첫번째로 우리팀이 더 헷갈렸던 이유**는 해당 구조체를 쓰는 API가 두 군데인데 다른 API에서는 decode에러 없이 잘되었던  점이였습니다.
그렇게 찾다가 URL을 보기 시작했고 확인해본 결과

> http://3.34.174.158/api/v1/article%3fcategory=BUDGET

위와 같은 URL이였고, "?"가 encoding되면서 %3F로 바뀐 것이 문제의 원인이였습니다. 우리팀은 URLComponent를 이용해서 `URL`만들고 있었기 때문에 Query도 URLComponent의 Query Item으로 만들어서 넣어주어야했습니다.

이 사실을 깨닫기까지 **두번째로 팀을 헷갈리게 만들었던 이유**는 `http://3.34.174.158/api/v1/article%3fcategory=BUDGET`로 URL을 만들어서 요청을 보냈다면 잘못된 URL로 요청이 갔다면 URLSession에서 에러를 던졌을 것이다라는 전제였기에 Data가 왔다면 요청은 성공했다라고생각했었습니다. 

하지만 실제 위의 잘못만들어진 URL을 확인해보니 아래 사진과 같은 `HTML`이 있었고, 이는 SpringBoot에서 제공되는 에러 페이지라는 것을 확인했습니다.

<img width="600" alt="image" src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/60292150/0fb23775-006f-44d7-80e7-c0068206b51b">


## 🚀 결론 및 사용법
따라서 NetworkRequest를 생성할 때 Query Item도 받게끔 수정했습니다.

```swift
struct Query: Request {
    let category: String
}

func getArticleListByCategory(categoryString: String) async throws -> [ArticleDataByWeek] {

    let query = Query(category: categoryString)

    let urlRequest = try NetworkRequest(path: "/v1/article", httpMethod: .post, query: query).makeURLRequest(isLogined: true)
...
```
- 위와 같이 Body를 넣었을 때와 마찬가지로 구조체를 만들고 Request프로토콜을 채택 후에 해당 구조체를 NetworkRequest를 생성할 때 넘겨주시면 됩니다.

```swift
func makeURLRequest(isLogined: Bool) throws -> URLRequest {
        var urlComponents = URLComponents(string: Config.baseURL)

        if let query = self.query {
            let queries = query.toDictionary()
            let queryItemArray = queries.map {
                return URLQueryItem(name: $0.key, value: "\($0.value)")
            }
            urlComponents?.queryItems = queryItemArray
        }
```
- 넘겨받은 구조체는 Dictionary로 변환 후 Dictionary를 다시 URLQueryItem으로 변환 시킨 후에 queryItems에 넣어줌으로써 Query String을 포함한 URL을 만들게 됩니다.


## 📮 관련 이슈

- Resolved: #96 
