### PR TITLE
[FEAT] LoadingView뷰 추가 (#104)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Global/Protocols/ViewControllerServiceable.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Protocols/ViewControllerServiceable.swift
@@ -7,21 +7,6 @@
 
 import UIKit
 
-final class LHLoadingView: UIActivityIndicatorView {
-
-    init() {
-        super.init(frame: .zero)
-        self.style = .large
-        self.color = .designSystem(.lionRed)
-        self.backgroundColor = .designSystem(.black)
-        self.frame = .init(x: 0, y: 0, width: Constant.Screen.width, height: Constant.Screen.height)
-    }
-
-    required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
 
 /// 네트워크 요청을 하는 ViewController가 채택하는 프로토콜
 protocol ViewControllerServiceable where Self: UIViewController {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewControllers/ArticleCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewControllers/ArticleCategoryViewController.swift
@@ -23,11 +23,7 @@ final class ArticleCategoryViewController: UIViewController {
     
     private lazy var navigationBar = LHNavigationBarView(type: .explore, viewController: self)
     
-    private var dummyCase = CategoryImage.dummy() {
-        didSet {
-            self.categoryArticleCollectionView.reloadData()
-        }
-    }
+    private var dummyCase = CategoryImage.dummy()
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
@@ -45,10 +45,12 @@ final class ArticleListByCategoryViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        showLoading()
         Task {
             do {
                 self.articleListData = try await ArticleService.shared.getArticleListByCategory(categoryString: categoryString)
                 self.articleListTableView.reloadData()
+                hideLoading()
             } catch {
                 guard let error = error as? NetworkError else { return }
                 handleError(error)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
@@ -35,11 +35,11 @@ final class BookmarkViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        LoadingIndicator.showLoading()
+        showLoading()
         Task {
             do {
                 self.bookmarkAppData = try await BookmarkService.shared.getBookmark()
-                LoadingIndicator.hideLoading()
+                hideLoading()
                 bookmarkCollectionView.reloadData()
             } catch {
                 guard let error = error as? NetworkError else { return }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekTableViewCell.swift
@@ -10,9 +10,6 @@ import UIKit
 
 import SnapKit
 
-struct BookmarkButtonTapped{
-    
-}
 
 final class CurriculumArticleByWeekTableViewCell: UITableViewCell, TableViewCellRegisterDequeueProtocol {
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumListByWeekViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumListByWeekViewController.swift
@@ -76,6 +76,7 @@ final class CurriculumListByWeekViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        showLoading()
         getListByWeekData()
     }
     
@@ -139,6 +140,7 @@ private extension CurriculumListByWeekViewController {
                 
                 try await BookmarkService.shared.postBookmark(BookmarkRequest(articleId: listByWeekDatas[indexPath].articleId,
                                                                               bookmarkStatus: buttonSelected))
+                hideLoading()
             } catch {
                 guard let error = error as? NetworkError else { return }
                 handleError(error)
@@ -164,7 +166,7 @@ private extension CurriculumListByWeekViewController {
         guard let articleId = notification.object as? Int else { return }
         
         let articleDetailVC = ArticleDetailViewController()
-        //TODO: - articleId
+        articleDetailVC.setArticleId(id: articleId)
         articleDetailVC.modalPresentationStyle = .overFullScreen
         self.present(articleDetailVC, animated: true)
         
@@ -226,10 +228,10 @@ extension CurriculumListByWeekViewController {
     func getListByWeekData() {
         Task {
             do {
-                let responseListByWeek = try await CurriculumService.shared.getArticleListByWeekInfo(week: 6)
+                let responseListByWeek = try await CurriculumService.shared.getArticleListByWeekInfo(week: weekToIndexPathItem + 4)
                 
                 listByWeekDatas = responseListByWeek
-                
+                hideLoading()
             } catch {
                 guard let error = error as? NetworkError else { return }
                 handleError(error)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
@@ -92,6 +92,7 @@ final class CurriculumViewController: UIViewController, CurriculumTableViewToggl
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        showLoading()
         getCurriculumData()
         
     }
@@ -286,7 +287,7 @@ extension CurriculumViewController {
                 let responseCurriculum = try await CurriculumService.shared.getCurriculumServiceInfo()
                 
                 userInfoData = responseCurriculum
-                
+                hideLoading()
             } catch {
                 guard let error = error as? NetworkError else { return }
                 handleError(error)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/OnboardingViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Onboarding/ViewControllers/OnboardingViewController.swift
@@ -25,7 +25,6 @@ final class OnboardingViewController: UIViewController {
     private let onboardingViewController = LHOnboardingPageViewController()
     private var pageDataSource: OnboardingViews = []
     private lazy var onboardingNavigationbar = LHNavigationBarView(type: .onboarding, viewController: self)
-    private let loadingIndicatorView = LHLoadingView()
     
     /// onboarding flow property
     private var currentPage: OnboardingPageType = .getPregnancy
@@ -169,11 +168,10 @@ private extension OnboardingViewController {
         let passingData = UserOnboardingModel(kakaoAccessToken: self.kakaoAccessToken, pregnacny: self.pregnancy, fetalNickname: self.fetalNickName)
         completeViewController.userData = passingData
         Task {
-            self.view.addSubview(loadingIndicatorView)
-            loadingIndicatorView.startAnimating()
+            showLoading()
             do {
                 try await AuthService.shared.signUp(type: .kakao, onboardingModel: passingData)
-                self.loadingIndicatorView.stopAnimating()
+                hideLoading()
                 self.navigationController?.pushViewController(completeViewController, animated: true)
 
             } catch {


### PR DESCRIPTION
## [#104] FEAT : LoadingView뷰 추가

## 🌱 작업한 내용

- [x] 투데이 화면
- [x] 온보딩 -> 온보딩 완료 화면
- [x] 북마크 메인
- [x] 아티클 상세뷰
- [x] 커리큘럼 메인화면
- [x] 커리큘럼 주차별 화면
- [x] 아티클 카테코리별 화면

네트워크 통신이 필요한 뷰에 로딩뷰를 적용하고 빌드를 통해 확인했습니다!


## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 로딩뷰 적용 |<img src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/60292150/71fd994c-65ca-4bbf-a5a8-b8fbe2a203fb" width="300"/> |



## 📮 관련 이슈

- Resolved: #104 
