### PR TITLE
[FIX] 주차별 커리큘럼 조회 화면에서 오른쪽 버튼 클릭시 앱 터지는 에러 해결 (#108)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Network/DTO/ArticleListByCategory/ArticleListByCategoryResponse.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/DTO/ArticleListByCategory/ArticleListByCategoryResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CategoryList: DTO, Response {
-    let categoryArticles: [ArticleListByCategoryResponse]?
+    let categoryArticles: [ArticleListByCategoryResponse]
 }
 
 struct ArticleListByCategoryResponse: DTO, Response {
@@ -19,4 +19,22 @@ struct ArticleListByCategoryResponse: DTO, Response {
     let requiredTime: Int
     let isMarked: Bool
     let tags: [String]
+}
+
+extension CategoryList {
+    func toAppData() -> CurriculumWeekData {
+
+        let articles = self.categoryArticles.map { response in
+            return ArticleDataByWeek(articleId: response.articleId,
+                                     articleTitle: response.title,
+                                     articleImage: response.mainImageUrl,
+                                     articleContent: response.firstBodyContent,
+                                     articleReadTime: response.requiredTime,
+                                     isArticleBookmarked: response.isMarked,
+                                     articleTags: response.tags)
+        }
+
+
+        return CurriculumWeekData(articleData: articles, week: nil)
+    }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Network/DTO/Curriculum/CurriculumResponse.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/DTO/Curriculum/CurriculumResponse.swift
@@ -16,6 +16,7 @@ struct CurriculumResponse: DTO, Response {
 
 struct CurriculumListByWeekResponse: DTO, Response {
     let articleSummaries: [CategoryArticle]
+    let week: Int
 }
 
 struct CategoryArticle: Response {
@@ -30,9 +31,11 @@ struct CategoryArticle: Response {
 
 /// CurriculumListByWeekResponse -> [ArticleDataByWeek]
 extension CurriculumListByWeekResponse {
-    func toAppData() -> [ArticleDataByWeek] {
-        return self.articleSummaries.map { article in
+    func toAppData() -> CurriculumWeekData {
+        let articles = self.articleSummaries.map { article in
             ArticleDataByWeek(articleId: article.articleId, articleTitle: article.title, articleImage: article.mainImageUrl, articleContent: article.firstBodyContent, articleReadTime: article.requiredTime, isArticleBookmarked: article.isMarked, articleTags: article.tags)
         }
+
+        return CurriculumWeekData(articleData: articles, week: self.week)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Network/Services/ArticleService.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/Services/ArticleService.swift
@@ -37,7 +37,7 @@ final class ArticleService: Serviceable {
         return model.toAppData()
     }
     
-    func getArticleListByCategory(categoryString: String) async throws -> [ArticleDataByWeek] {
+    func getArticleListByCategory(categoryString: String) async throws -> CurriculumWeekData {
         let query = Query(category: categoryString)
 
         let urlRequest = try NetworkRequest(path: "/v1/article", httpMethod: .get, query: query).makeURLRequest(isLogined: true)
@@ -45,7 +45,7 @@ final class ArticleService: Serviceable {
         let (data, _) = try await URLSession.shared.data(for: urlRequest)
         
         guard let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: CurriculumListByWeekResponse.self) else {
-            return [ArticleDataByWeek.emptyData]
+            return .init(articleData: [], week: nil)
         }
         
         return model.toAppData()

--- a/LionHeart-iOS/LionHeart-iOS/Network/Services/CurriculumViewService.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/Services/CurriculumViewService.swift
@@ -22,14 +22,14 @@ final class CurriculumService: Serviceable {
         return UserInfoData(userWeekInfo: model.week, userDayInfo: model.day, progress: model.progress + 1, remainingDay: model.remainingDay)
     }
     
-    func getArticleListByWeekInfo(week: Int) async throws -> [ArticleDataByWeek] {
+    func getArticleListByWeekInfo(week: Int) async throws -> CurriculumWeekData {
         let urlRequest = try NetworkRequest(path: "v1/article/week/\(week)", httpMethod: .get).makeURLRequest(isLogined: true)
         
         let (data, _) = try await URLSession.shared.data(for: urlRequest)
         guard let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: CurriculumListByWeekResponse.self) else {
-            return [ArticleDataByWeek.emptyData]
+            return .init(articleData: [], week: 0)
         }
-        
+
         return model.toAppData()
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
@@ -52,7 +52,7 @@ final class ArticleListByCategoryViewController: UIViewController {
         showLoading()
         Task {
             do {
-                self.articleListData = try await ArticleService.shared.getArticleListByCategory(categoryString: categoryString)
+                self.articleListData = try await ArticleService.shared.getArticleListByCategory(categoryString: categoryString).articleData
                 self.articleListTableView.reloadData()
                 hideLoading()
             } catch {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekRowZeroTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekRowZeroTableViewCell.swift
@@ -16,8 +16,7 @@ final class CurriculumArticleByWeekRowZeroTableViewCell: UITableViewCell, TableV
         didSet {
             guard let inputData else { return }
             //inputData는 row가 0부터인데 주차정보는 4주차부터 시작이므로 +4를 해줌
-            let userWeek = inputData + 4
-            weekLabel.text = "\(userWeek)주차"
+            weekLabel.text = "\(inputData)주차"
             
         }
     }
@@ -48,6 +47,7 @@ final class CurriculumArticleByWeekRowZeroTableViewCell: UITableViewCell, TableV
         let button = UIButton(type: .custom)
         button.setImage(ImageLiterals.Curriculum.arrowRightWeek, for: .normal)
         button.addButtonAction { _ in
+
             NotificationCenter.default.post(name: NSNotification.Name("rightButton"),
                                             object: nil)
         }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumListByWeekCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumListByWeekCollectionViewCell.swift
@@ -16,7 +16,7 @@ final class CurriculumListByWeekCollectionViewCell: UICollectionViewCell, Collec
         static let weekBackGroundImageSize: CGFloat = (60 / 375) * Constant.Screen.width
     }
     
-    private let curriculumListByWeekTableView: UITableView = {
+    let curriculumListByWeekTableView: UITableView = {
         let tableView = UITableView()
         tableView.contentInsetAdjustmentBehavior = .always
         tableView.showsVerticalScrollIndicator = false
@@ -25,9 +25,13 @@ final class CurriculumListByWeekCollectionViewCell: UICollectionViewCell, Collec
         return tableView
     }()
     
-    var weekCount: Int?
+    var weekCount: Int? {
+        didSet {
+            curriculumListByWeekTableView.reloadData()
+        }
+    }
     
-    var inputData: [ArticleDataByWeek]? {
+    var inputData: CurriculumWeekData? {
         
         didSet {
             curriculumListByWeekTableView.reloadData()
@@ -98,20 +102,21 @@ private extension CurriculumListByWeekCollectionViewCell {
 extension CurriculumListByWeekCollectionViewCell: UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let inputData else { return  0}
-        return (inputData.count + 1)
+        guard let inputData else { return 0 }
+        return (inputData.articleData.count + 1)
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.row == 0 {
 
             let cell = CurriculumArticleByWeekRowZeroTableViewCell.dequeueReusableCell(to: curriculumListByWeekTableView)
-            cell.inputData = self.weekCount
+            guard let weekCount else { return CurriculumTableViewCell() }
+            cell.inputData = inputData?.week
             return cell
         } else {
             
             let cell = CurriculumArticleByWeekTableViewCell.dequeueReusableCell(to: curriculumListByWeekTableView)
-            cell.inputData = inputData?[indexPath.row - 1]
+            cell.inputData = inputData?.articleData[indexPath.row - 1]
             cell.selectionStyle = .none
             cell.backgroundColor = .designSystem(.background)
             cell.isBookmarkedIndexPath = indexPath
@@ -125,7 +130,7 @@ extension CurriculumListByWeekCollectionViewCell: UITableViewDataSource{
         } else {
             guard let inputData else { return }
             NotificationCenter.default.post(name: NSNotification.Name("didSelectTableViewCell"),
-                                            object: inputData[indexPath.row - 1].articleId)
+                                            object: inputData.articleData[indexPath.row - 1].articleId)
             
         }
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Model/CurriculumListByWeekData.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Model/CurriculumListByWeekData.swift
@@ -9,10 +9,10 @@ import UIKit
 
 struct CurriculumWeekData: AppData {
     var articleData: [ArticleDataByWeek]
+    let week: Int?
 }
 
 struct ArticleDataByWeek: AppData {
-    
     let articleId: Int
     let articleTitle: String
     let articleImage: String

--- a/LionHeart-iOS/LionHeart-iOS/Settings/Info.plist
+++ b/LionHeart-iOS/LionHeart-iOS/Settings/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>UIStatusBarStyle</key>


### PR DESCRIPTION
## [#108] FIX : 주차별 커리큘럼 조회 화면에서 오른쪽 버튼 클릭시 앱 터지는 에러 해결

## 🌱 작업한 내용

기존에는 데이터가 1개밖에 존재하지 않아서 고려하지 못했던 문제들을 모든 데이터가 추가된 후의 상황에 맞게 로직을 모두 수정하였고 잘동작하는 것을 확인하였습니다.
 

## 🌱 PR Point

- PR Point 1
- PR Point 2

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| ex. 로그인 화면 | 파일첨부바람 |

## 📮 관련 이슈

- Resolved: #108 
