### PR TITLE
[FIX] 1차 내부 QA (#114)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIView+.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIView+.swift
@@ -35,7 +35,7 @@ extension UIView{
         case horizontal
     }
     
-    func setGradient(firstColor: UIColor, secondColor: UIColor, axis: GradientAxis){
+    func setGradient(firstColor: UIColor, secondColor: UIColor, axis: GradientAxis) {
         let gradient: CAGradientLayer = CAGradientLayer()
         gradient.colors = [firstColor.cgColor, secondColor.cgColor]
         if axis == .horizontal {

--- a/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIViewController+.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIViewController+.swift
@@ -77,3 +77,22 @@ extension UIViewController {
     }
 }
 
+/**
+
+  - Description:
+    ArticleDetailViewController로 fullscreen으로 present해주는 메서드입니다
+
+  - parameters:
+    articleID를 넘겨줍니다
+ 
+*/
+
+extension UIViewController {
+    func presentArticleDetailFullScreen(articleID: Int) {
+        let articleDetailViewController = ArticleDetailViewController()
+        articleDetailViewController.setArticleId(id: articleID)
+        articleDetailViewController.isModalInPresentation = true
+        articleDetailViewController.modalPresentationStyle = .overFullScreen
+        self.present(articleDetailViewController, animated: true)
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -52,6 +52,7 @@ final class ArticleDetailViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+        setUI()
         setHierarchy()
         setLayout()
         setTableView()
@@ -121,6 +122,10 @@ extension ArticleDetailViewController: ViewControllerServiceable {
 
 private extension ArticleDetailViewController {
     
+    func setUI() {
+        view.backgroundColor = .designSystem(.background)
+    }
+    
     func setHierarchy() {
         view.addSubviews(navigationBar, articleTableView, progressBar, scrollToTopButton)
     }
@@ -138,7 +143,7 @@ private extension ArticleDetailViewController {
         articleTableView.snp.makeConstraints { make in
             make.top.equalTo(progressBar.snp.bottom)
             make.leading.trailing.equalToSuperview()
-            make.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.bottom.equalToSuperview()
         }
 
         scrollToTopButton.snp.makeConstraints { make in

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -78,10 +78,7 @@ extension ArticleDetailViewController {
     private func getArticleDetail() {
         Task {
             do {
-                guard let articleId else {
-                    return
-
-                }
+                guard let articleId else { return }
                 self.articleDatas = try await ArticleService.shared.getArticleDetail(articleId: articleId)
             } catch {
                 guard let error = error as? NetworkError else { return }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Views/ArticleDetailTableView.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Views/ArticleDetailTableView.swift
@@ -21,7 +21,7 @@ class ArticleDetailTableView: UITableView {
     }
 
     private func setUI() {
-        self.backgroundColor = .designSystem(.black)
+        self.backgroundColor = .designSystem(.background)
     }
 
     private func setTableView() {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
@@ -144,10 +144,6 @@ extension ArticleListByCategoryViewController: UITableViewDataSource {
 
 extension ArticleListByCategoryViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let articleDetailViewController = ArticleDetailViewController()
-        articleDetailViewController.setArticleId(id: articleListData[indexPath.row].articleId)
-        articleDetailViewController.isModalInPresentation = true
-        articleDetailViewController.modalPresentationStyle = .overFullScreen
-        self.present(articleDetailViewController, animated: true)
+        self.presentArticleDetailFullScreen(articleID: articleListData[indexPath.row].articleId)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
@@ -34,15 +34,9 @@ final class ArticleListByCategoryViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
-        
         setHierarchy()
-        
         setLayout()
-        
-        setAddTarget()
-        
         setDelegate()
-        
         setTableView()
         setNotificationCenter()
     }
@@ -85,12 +79,9 @@ private extension ArticleListByCategoryViewController {
         }
     }
     
-    func setAddTarget() {
-        
-    }
-    
     func setDelegate() {
         articleListTableView.dataSource = self
+        articleListTableView.delegate = self
     }
     
     func setTableView() {
@@ -148,5 +139,15 @@ extension ArticleListByCategoryViewController: UITableViewDataSource {
         let cell = CurriculumArticleByWeekTableViewCell.dequeueReusableCell(to: articleListTableView)
         cell.inputData = articleListData[indexPath.item]
         return cell
+    }
+}
+
+extension ArticleListByCategoryViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let articleDetailViewController = ArticleDetailViewController()
+        articleDetailViewController.setArticleId(id: articleListData[indexPath.row].articleId)
+        articleDetailViewController.isModalInPresentation = true
+        articleDetailViewController.modalPresentationStyle = .overFullScreen
+        self.present(articleDetailViewController, animated: true)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/Cells/ChallengeDayCheckCollectionViewCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/Cells/ChallengeDayCheckCollectionViewCollectionViewCell.swift
@@ -12,23 +12,11 @@ import SnapKit
 
 final class ChallengeDayCheckCollectionViewCollectionViewCell: UICollectionViewCell, CollectionViewCellRegisterDequeueProtocol {
     
-    var textColorBool = false
-    
-    var inputData: DummyModel? {
-        didSet {
-            
-        }
-    }
+    var inputData: DummyModel?
     
     var inputString: String? {
         didSet {
             countLabel.text = inputString
-            
-            if textColorBool {
-                countLabel.textColor = .designSystem(.white)
-            } else {
-                countLabel.textColor = .designSystem(.gray600)
-            }
         }
     }
     
@@ -48,20 +36,9 @@ final class ChallengeDayCheckCollectionViewCollectionViewCell: UICollectionViewC
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        // MARK: - 컴포넌트 설정
         setUI()
-        
-        // MARK: - addsubView
         setHierarchy()
-        
-        // MARK: - autolayout설정
         setLayout()
-        
-        // MARK: - button의 addtarget설정
-        setAddTarget()
-        
-        // MARK: - delegate설정
-        setDelegate()
     }
     
     @available(*, unavailable)
@@ -89,13 +66,5 @@ private extension ChallengeDayCheckCollectionViewCollectionViewCell {
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(1)
         }
-    }
-    
-    func setAddTarget() {
-        
-    }
-    
-    func setDelegate() {
-        
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
@@ -161,6 +161,7 @@ final class ChallengeViewController: UIViewController {
         setLayout()
         setNavigationBar()
         setDelegate()
+        setAddTarget()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -241,6 +242,18 @@ private extension ChallengeViewController {
         navigationBar.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.leading.trailing.equalToSuperview()
+        }
+    }
+    
+    func setAddTarget() {
+        navigationBar.rightFirstBarItemAction {
+            let bookmarkViewController = BookmarkViewController()
+            self.navigationController?.pushViewController(bookmarkViewController, animated: true)
+        }
+        
+        navigationBar.rightSecondBarItemAction {
+            let myPageViewController = MyPageViewController()
+            self.navigationController?.pushViewController(myPageViewController, animated: true)
         }
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumListByWeekViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumListByWeekViewController.swift
@@ -188,11 +188,7 @@ private extension CurriculumListByWeekViewController {
     @objc
     func didSelectTableVIewCell(notification: NSNotification) {
         guard let articleId = notification.object as? Int else { return }
-        
-        let articleDetailVC = ArticleDetailViewController()
-        articleDetailVC.setArticleId(id: articleId)
-        articleDetailVC.modalPresentationStyle = .overFullScreen
-        self.present(articleDetailVC, animated: true)
+        presentArticleDetailFullScreen(articleID: articleId)
         
     }
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Splash/SplashViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Splash/SplashViewController.swift
@@ -118,10 +118,10 @@ private extension SplashViewController {
                 guard let token = UserDefaultsManager.tokenKey else { return }
                 await logout(token: token)
                 // LoginVC로 이동하기
-                let loginVC = LoginViewController()
+                let loginVC = UINavigationController(rootViewController: LoginViewController())
                 setRootViewController(to: loginVC, animation: true)
             } else if code == NetworkErrorCode.unfoundUserErrorCode {
-                let loginVC = LoginViewController()
+                let loginVC = UINavigationController(rootViewController: LoginViewController())
                 setRootViewController(to: loginVC, animation: true)
             }
         default:

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
@@ -169,10 +169,7 @@ private extension TodayViewController {
     }
     
     @objc func articleTapped(_ sender: UIButton) {
-        let articleDetailViewController = ArticleDetailViewController()
-        articleDetailViewController.setArticleId(id: self.todayArticleID)
-        articleDetailViewController.isModalInPresentation = true
-        articleDetailViewController.modalPresentationStyle = .overFullScreen
-        self.present(articleDetailViewController, animated: true)
+        guard let todayArticleID else { return }
+        self.presentArticleDetailFullScreen(articleID: todayArticleID)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
@@ -56,29 +56,6 @@ final class TodayViewController: UIViewController {
     }
 }
 
-// MARK: - 네트워킹
-extension TodayViewController: ViewControllerServiceable {
-    func handleError(_ error: NetworkError) {
-        switch error {
-        case .urlEncodingError:
-            LHToast.show(message: "URL인코딩오류입니다", isTabBar: true)
-        case .jsonDecodingError:
-            LHToast.show(message: "Json디코딩오류입니다", isTabBar: true)
-        case .badCasting:
-            LHToast.show(message: "배드퀘스트", isTabBar: true)
-        case .fetchImageError:
-            LHToast.show(message: "이미지패치실패", isTabBar: true)
-        case .unAuthorizedError:
-            guard let window = self.view.window else { return }
-            ViewControllerUtil.setRootViewController(window: window, viewController: SplashViewController(), withAnimation: false)
-        case .clientError(_, let message):
-            LHToast.show(message: message, isTabBar: true)
-        case .serverError:
-            LHToast.show(message: "승준이어딧니 내목소리들리니", isTabBar: true)
-        }
-    }
-}
-
 extension TodayViewController {
     func getInquireTodayArticle() {
         Task {
@@ -89,7 +66,10 @@ extension TodayViewController {
                 titleLabel.userNickName = responseArticle.fetalNickname
                 mainArticleView.data = responseArticle
                 todayArticleID = responseArticle.aticleID
-                hideLoading()
+                // MARK: - 추후에 디팀에서 그라데이션있는 이미지로 받아오기로함
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self.hideLoading()
+                }
             } catch {
                 guard let error = error as? NetworkError else { return }
                 handleError(error)
@@ -112,7 +92,6 @@ private extension TodayViewController {
     func setHierarchy() {
         view.addSubviews(todayNavigationBar, seperateLine)
         view.addSubviews(titleLabel, subTitleLable, pointImage, mainArticleView)
-        
     }
     
     func setLayout() {
@@ -171,5 +150,28 @@ private extension TodayViewController {
     @objc func articleTapped(_ sender: UIButton) {
         guard let todayArticleID else { return }
         self.presentArticleDetailFullScreen(articleID: todayArticleID)
+    }
+}
+
+// MARK: - 네트워킹
+extension TodayViewController: ViewControllerServiceable {
+    func handleError(_ error: NetworkError) {
+        switch error {
+        case .urlEncodingError:
+            LHToast.show(message: "URL인코딩오류입니다", isTabBar: true)
+        case .jsonDecodingError:
+            LHToast.show(message: "Json디코딩오류입니다", isTabBar: true)
+        case .badCasting:
+            LHToast.show(message: "배드퀘스트", isTabBar: true)
+        case .fetchImageError:
+            LHToast.show(message: "이미지패치실패", isTabBar: true)
+        case .unAuthorizedError:
+            guard let window = self.view.window else { return }
+            ViewControllerUtil.setRootViewController(window: window, viewController: SplashViewController(), withAnimation: false)
+        case .clientError(_, let message):
+            LHToast.show(message: message, isTabBar: true)
+        case .serverError:
+            LHToast.show(message: "승준이어딧니 내목소리들리니", isTabBar: true)
+        }
     }
 }


### PR DESCRIPTION
## [#114] FIX : 1차 내부 QA

## 🌱 작업한 내용
- ArticleDetailView 레이아웃 수정
- Category Article List에서 ArticleDetailView 연결
- ChallengeViewController에 navibar 버튼 action 연결
- ChallengeViewController 에러핸들링 및 loadingView추가

## 🌱 PR Point
### ArticleDetailView 레이아웃 수정
1. ArticleDetailView bottom부분이 safeLayout기준으로 되어있어서 아래부분에 background부분이 보이는 문제를 해결헀습니다
2. ArticleDetailView 내부 tableView를 아래로 드래그했을때 backgroundColor가 figma와 다른부분을 변경했습니다

### Category Article List에서 ArticleDetailView 연결
1. 카테고리별 아티클 리스트에서 articleDetailView로 articleID를 넘겨줘서 아티클상세뷰를 띄워주는 작업을 했습니다
2. 아티클리스트를 띄우는 과정에서 present를 사용해야하고 `isModalInPresentation`이나 `modalPresentationStyle`을 지정해줘야하는 번거로움이 있어서 UIViewController Extension에 detailViewController를 present해주는 메서드를 만들었습니다
```swift
extension UIViewController {
    func presentArticleDetailFullScreen(articleID: Int) {
        let articleDetailViewController = ArticleDetailViewController()
        articleDetailViewController.setArticleId(id: articleID)
        articleDetailViewController.isModalInPresentation = true
        articleDetailViewController.modalPresentationStyle = .overFullScreen
        self.present(articleDetailViewController, animated: true)
    }
}
```

### ChallengeView에 미구현된부분이 있어서 구현했습니다
1. api호출시 error toast handling을 구현했습니다
2. api호출시 loadingview를 구현헀습니다


## 📮 관련 이슈

- Resolved: #114 
