### PR TITLE
[Fix] 커리큘럼메인에서 scrollToRow 분기처리(#117)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
@@ -185,14 +185,26 @@ private extension CurriculumViewController {
         guard let userInfoData else { return }
         
         let userWeek = userInfoData.userWeekInfo
-        let weekPerMonth = 4
-        let desireSection = (userWeek / weekPerMonth) - 1
-        let desireRow = (userWeek % weekPerMonth)
-        let indexPath = IndexPath(row: desireRow, section: desireSection)
         
-        curriculumViewDatas[desireSection].weekDatas[desireRow].isExpanded = true
-        self.curriculumTableView.reloadData()
-        self.curriculumTableView.scrollToRow(at: indexPath, at: .top, animated: false)
+        if userWeek == 40 {
+            let weekPerMonth = 4
+            let desireSection = (userWeek / weekPerMonth) - 2
+            let desireRow = (userWeek % weekPerMonth)
+            let indexPath = IndexPath(row: desireRow, section: desireSection)
+            
+            curriculumViewDatas[desireSection].weekDatas[desireRow+4].isExpanded = true
+            self.curriculumTableView.reloadData()
+            self.curriculumTableView.scrollToRow(at: indexPath, at: .top, animated: false)
+        } else {
+            let weekPerMonth = 4
+            let desireSection = (userWeek / weekPerMonth) - 1
+            let desireRow = (userWeek % weekPerMonth)
+            let indexPath = IndexPath(row: desireRow, section: desireSection)
+            
+            curriculumViewDatas[desireSection].weekDatas[desireRow].isExpanded = true
+            self.curriculumTableView.reloadData()
+            self.curriculumTableView.scrollToRow(at: indexPath, at: .top, animated: false)
+        }
     }
     
     func configureUserInfoData() {


### PR DESCRIPTION
## [#100] FEAT : 로그인 구현

## 🌱 작업한 내용

- 커리큘럼메인에서 scrollToRow 분기처리
10개월 Section에만 5개의 주차가 있어서 40주차만 따로 분기처리 해주었습니다.
```swift
func scrollToUserWeek() {
        
        guard let userInfoData else { return }
        
        let userWeek = userInfoData.userWeekInfo
        
        if userWeek == 40 {
            let weekPerMonth = 4
            let desireSection = (userWeek / weekPerMonth) - 2
            let desireRow = (userWeek % weekPerMonth)
            let indexPath = IndexPath(row: desireRow, section: desireSection)
            
            curriculumViewDatas[desireSection].weekDatas[desireRow+4].isExpanded = true
            self.curriculumTableView.reloadData()
            self.curriculumTableView.scrollToRow(at: indexPath, at: .top, animated: false)
        } else {
            let weekPerMonth = 4
            let desireSection = (userWeek / weekPerMonth) - 1
            let desireRow = (userWeek % weekPerMonth)
            let indexPath = IndexPath(row: desireRow, section: desireSection)
            
            curriculumViewDatas[desireSection].weekDatas[desireRow].isExpanded = true
            self.curriculumTableView.reloadData()
            self.curriculumTableView.scrollToRow(at: indexPath, at: .top, animated: false)
        }
    }
```


## 📮 관련 이슈

- Resolved: #117
