### PR TITLE
[CHORE] 레이아웃 수정 및 사용자 경험 증진 (#121)

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIButton+.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIButton+.swift
@@ -21,7 +21,7 @@ extension UIButton {
 
 extension UIButton {
     func marginImageWithText(margin: CGFloat) {
-        let halfSize = margin/2
+        let halfSize = margin / 2
         imageEdgeInsets = UIEdgeInsets(top: 0, left: -halfSize, bottom: 0, right: halfSize)
         titleEdgeInsets = UIEdgeInsets(top: 0, left: halfSize, bottom: 0, right: -halfSize)
         contentEdgeInsets = UIEdgeInsets(top: 0, left: halfSize, bottom: 0, right: halfSize)

--- a/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIViewController+.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIViewController+.swift
@@ -92,7 +92,7 @@ extension UIViewController {
         let articleDetailViewController = ArticleDetailViewController()
         articleDetailViewController.setArticleId(id: articleID)
         articleDetailViewController.isModalInPresentation = true
-        articleDetailViewController.modalPresentationStyle = .overFullScreen
+        articleDetailViewController.modalPresentationStyle = .fullScreen
         self.present(articleDetailViewController, animated: true)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHNavigationBarView.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHNavigationBarView.swift
@@ -21,6 +21,7 @@ final class LHNavigationBarView: UIView {
     private let leftBarItem: UIButton = {
         let button = UIButton()
         button.tintColor = .designSystem(.white)
+        button.marginImageWithText(margin: 14)
         return button
     }()
 
@@ -28,6 +29,7 @@ final class LHNavigationBarView: UIView {
         let button = UIButton()
         button.setImage(ImageLiterals.NavigationBar.bookMark, for: .normal)
         button.tintColor = .designSystem(.white)
+        button.marginImageWithText(margin: 14)
         return button
     }()
 
@@ -35,6 +37,7 @@ final class LHNavigationBarView: UIView {
         let button = UIButton()
         button.setImage(ImageLiterals.NavigationBar.profile, for: .normal)
         button.tintColor = .designSystem(.white)
+        button.marginImageWithText(margin: 14)
         return button
     }()
 
@@ -49,7 +52,6 @@ final class LHNavigationBarView: UIView {
             rightFirstBarItem, rightSecondBarItem
         ])
         stackView.axis = .horizontal
-        stackView.spacing = 8
         stackView.alignment = .center
         stackView.distribution = .equalSpacing
         stackView.isHidden = true
@@ -110,7 +112,7 @@ final class LHNavigationBarView: UIView {
 
         rightBarItemsStackView.snp.makeConstraints { make in
             make.centerY.equalTo(leftBarItem)
-            make.trailing.equalToSuperview().inset(24)
+            make.trailing.equalToSuperview().inset(16)
         }
 
         graySepartorLine.snp.makeConstraints { make in

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Cells/BodyTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/Cells/BodyTableViewCell.swift
@@ -74,6 +74,7 @@ private extension BodyTableViewCell {
         guard let model else { return }
         if let caption = model.caption {
             captionLabel.text = caption
+            captionLabel.setTextWithLineHeight(lineHeight: 22)
             captionLabel.snp.makeConstraints { make in
                 make.top.equalTo(bodyLabel.snp.bottom).offset(8)
                 make.leading.trailing.equalTo(bodyLabel)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -89,6 +89,7 @@ extension ArticleDetailViewController {
             do {
                 let bookmarkRequest = BookmarkRequest(articleId: articleId, bookmarkStatus: isSelected)
                 try await BookmarkService.shared.postBookmark(bookmarkRequest)
+                LHToast.show(message: "북마크가 추가되었습니다")
                 isBookMarked = isSelected
             } catch {
                 guard let error = error as? NetworkError else { return }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekRowZeroTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekRowZeroTableViewCell.swift
@@ -33,6 +33,12 @@ final class CurriculumArticleByWeekRowZeroTableViewCell: UITableViewCell, TableV
         imageView.isUserInteractionEnabled = true
         return imageView
     }()
+
+    private let blurblackView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .designSystem(.black)?.withAlphaComponent(0.4)
+        return view
+    }()
     
     private lazy var leftWeekButton: UIButton = {
         let button = UIButton(type: .custom)
@@ -83,15 +89,9 @@ final class CurriculumArticleByWeekRowZeroTableViewCell: UITableViewCell, TableV
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        // MARK: - 컴포넌트 설정
         setUI()
-        
-        // MARK: - addsubView
         setHierarchy()
-        
-        // MARK: - autolayout설정
         setLayout()
-        
     }
 
     
@@ -108,9 +108,9 @@ private extension CurriculumArticleByWeekRowZeroTableViewCell {
     func setHierarchy() {
         
         curriculumAndWeekStackView.addArrangedSubviews(curriculumLabel, weekLabel)
-        weekBackGroundImageView.addSubviews(curriculumAndWeekStackView)
+        weekBackGroundImageView.addSubviews(blurblackView, curriculumAndWeekStackView)
         contentView.addSubviews(weekBackGroundImageView, leftWeekButton, rightWeekButton)
-
+        
     }
     
     func setLayout() {
@@ -118,6 +118,10 @@ private extension CurriculumArticleByWeekRowZeroTableViewCell {
         weekBackGroundImageView.snp.makeConstraints{
             $0.edges.equalToSuperview()
             $0.height.equalTo(weekBackGroundImageView.snp.width).multipliedBy(Size.weekBackGroundImageSize)
+        }
+
+        blurblackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
         
         leftWeekButton.snp.makeConstraints{

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumArticleByWeekTableViewCell.swift
@@ -26,6 +26,7 @@ final class CurriculumArticleByWeekTableViewCell: UITableViewCell, TableViewCell
             }
             articleTagLabel.text = inputData.articleTags.joined(separator: " · ")
             articleContentLabel.text = inputData.articleContent
+            articleContentLabel.setTextWithLineHeight(lineHeight: 22)
             articleContentLabel.lineBreakStrategy = .pushOut
             articleContentLabel.lineBreakMode = .byTruncatingTail
             bookMarkButton.isSelected = inputData.isArticleBookmarked

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumTableViewCell.swift
@@ -105,6 +105,7 @@ final class CurriculumTableViewCell: UITableViewCell, TableViewCellRegisterDeque
             self.weekTitleLabel.text = inputData.curriculumWeekTitle
             self.contentImageView.image = inputData.curriculumImage
             self.contentTextLabel.text = inputData.curriculumText
+            self.contentTextLabel.setTextWithLineHeight(lineHeight: 22)
             self.curriculumContentStackView.isHidden = !inputData.isExpanded // false -> true -> 안보이게됨
             self.weekLabel.textColor = inputData.isExpanded
             ? .designSystem(.componentLionRed)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumTableViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Cells/CurriculumTableViewCell.swift
@@ -80,6 +80,7 @@ final class CurriculumTableViewCell: UITableViewCell, TableViewCellRegisterDeque
     
     lazy var curriculumToggleDirectionButton: UIButton = {
         var button = UIButton()
+        button.marginImageWithText(margin: 19)
         button.setImage(ImageLiterals.Curriculum.arrowDownSmall, for: .normal)
         button.setImage(ImageLiterals.Curriculum.arrowUpSmall, for: .selected)
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -166,7 +167,7 @@ private extension CurriculumTableViewCell {
         curriculumToggleDirectionButton.snp.makeConstraints{
             $0.leading.greaterThanOrEqualTo(weekTitleLabel.snp.trailing).offset(8)
             $0.centerY.equalTo(weekLabel)
-            $0.trailing.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(12)
         }
         
         curriculumWholeStackView.snp.makeConstraints{

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Views/CurriculumUserInfoView.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/Views/CurriculumUserInfoView.swift
@@ -47,6 +47,7 @@ final class CurriculumUserInfoView: UIView {
         let label = UILabel()
         label.font = .pretendard(.head3)
         label.textColor = .designSystem(.gray100)
+        label.textAlignment = .center
         return label
     }()
     
@@ -67,13 +68,8 @@ final class CurriculumUserInfoView: UIView {
     }
     
     override func layoutSubviews() {
-        // MARK: - 컴포넌트 설정
         setUI()
-        
-        // MARK: - addsubView
         setHierarchy()
-        
-        // MARK: - autolayout설정
         setLayout()
     }
     
@@ -91,6 +87,7 @@ extension CurriculumUserInfoView {
     
     func setHierarchy() {
         self.addSubviews(userWeekDayInfoView, weekImageView, userWeekLabel, weekLabel, dayImageView, userDayLabel, dayLabel)
+        dayImageView.addSubview(userDayLabel)
     }
     
     func setLayout() {
@@ -116,8 +113,7 @@ extension CurriculumUserInfoView {
         }
         
         userDayLabel.snp.makeConstraints{
-            $0.leading.equalTo(dayImageView.snp.leading).offset(4)
-            $0.centerY.equalTo(dayImageView)
+            $0.center.equalToSuperview()
         }
         
         dayLabel.snp.makeConstraints{

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
@@ -20,12 +20,6 @@ final class TodayViewController: UIViewController {
 
     private lazy var todayNavigationBar = LHNavigationBarView(type: .today, viewController: self)
     
-    private let seperateLine: UIView = {
-        let view = UIView()
-        view.backgroundColor = .designSystem(.gray800)
-        return view
-    }()
-    
     private var titleLabel = LHTodayArticleTitle()
     private var subTitleLable = LHTodayArticleTitle(initalizeString: "오늘의 아티클이에요")
     private var mainArticleView = TodayArticleView()
@@ -90,7 +84,7 @@ private extension TodayViewController {
     }
     
     func setHierarchy() {
-        view.addSubviews(todayNavigationBar, seperateLine)
+        view.addSubviews(todayNavigationBar)
         view.addSubviews(titleLabel, subTitleLable, pointImage, mainArticleView)
     }
     
@@ -100,14 +94,8 @@ private extension TodayViewController {
             make.leading.trailing.equalToSuperview()
         }
         
-        seperateLine.snp.makeConstraints { make in
-            make.top.equalTo(todayNavigationBar.snp.bottom)
-            make.leading.trailing.equalToSuperview()
-            make.height.equalTo(1)
-        }
-        
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(seperateLine.snp.bottom).offset(53)
+            make.top.equalTo(todayNavigationBar.snp.bottom).offset(53)
             make.leading.equalToSuperview().inset(20)
         }
         


### PR DESCRIPTION
## [#121] CHORE : 레이아웃 수정

## 🌱 작업한 내용

- 레이아웃 수정 및 present style 변경
- 1차 QA 후 필요한 행간 높이 조절 및 ViewWillAppear호출을 위해 present의 style을 fullScreen으로 변경하였습니다.
- HIG를 참고해 잘눌리지 않았던 버튼 영역을 44px로 늘려서 사용자 경험을 증진시켰습니다.
https://developer.apple.com/design/human-interface-guidelines/buttons
<img width="764" alt="image" src="https://github.com/gosopt-LionHeart/LionHeart-iOS/assets/60292150/ea12a17e-1023-4b9f-a7c5-6afd1a8dc281">


## 📮 관련 이슈

- Resolved: #121 
