### PR TITLE
[Refactor] #129 - 북마크 네트워크 레이어 분리

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		4A8980D02A61850500746C58 /* MyPageAppSettingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8980CF2A61850500746C58 /* MyPageAppSettingCollectionViewCell.swift */; };
 		4AD216402A69AC1E00C9F2F2 /* MyPageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD2163F2A69AC1E00C9F2F2 /* MyPageResponse.swift */; };
 		4AD6A34C2AB1AB6700977224 /* BookmarkAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD6A34B2AB1AB6700977224 /* BookmarkAPI.swift */; };
-		4AD6A34E2AB1F92B00977224 /* BookmarkServiceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD6A34D2AB1F92B00977224 /* BookmarkServiceWrapper.swift */; };
 		4AD6AE1A2A68436B00A3D745 /* ArticleListByCategoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD6AE192A68436B00A3D745 /* ArticleListByCategoryResponse.swift */; };
 		4AE19A172A65864F00C1DB7E /* BookmarkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE19A162A65864F00C1DB7E /* BookmarkService.swift */; };
 		4AE19A1A2A65886100C1DB7E /* BookmarkReponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE19A192A65886100C1DB7E /* BookmarkReponse.swift */; };
@@ -234,7 +233,6 @@
 		4A8980CF2A61850500746C58 /* MyPageAppSettingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAppSettingCollectionViewCell.swift; sourceTree = "<group>"; };
 		4AD2163F2A69AC1E00C9F2F2 /* MyPageResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageResponse.swift; sourceTree = "<group>"; };
 		4AD6A34B2AB1AB6700977224 /* BookmarkAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkAPI.swift; sourceTree = "<group>"; };
-		4AD6A34D2AB1F92B00977224 /* BookmarkServiceWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkServiceWrapper.swift; sourceTree = "<group>"; };
 		4AD6AE032A66F83E00A3D745 /* progressbar_2m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_2m.json; sourceTree = "<group>"; };
 		4AD6AE052A66F84300A3D745 /* progressbar_3m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_3m.json; sourceTree = "<group>"; };
 		4AD6AE072A66F84C00A3D745 /* progressbar_4m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_4m.json; sourceTree = "<group>"; };
@@ -1140,7 +1138,6 @@
 				4AE19A162A65864F00C1DB7E /* BookmarkService.swift */,
 				C06E38292A662E3700B00600 /* ArticleService.swift */,
 				B57FEE2B2AA904D800ED6299 /* AuthMyPageServiceWrapper.swift */,
-				4AD6A34D2AB1F92B00977224 /* BookmarkServiceWrapper.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1651,7 +1648,6 @@
 				C06E38232A65353F00B00600 /* LoginType.swift in Sources */,
 				B5C6A2B62A5DD5FE0021BE5E /* TitleTableViewCell.swift in Sources */,
 				C0DF03962A5B8FB10037F740 /* Palette.swift in Sources */,
-				4AD6A34E2AB1F92B00977224 /* BookmarkServiceWrapper.swift in Sources */,
 				4A3D72872A5D405C00A36189 /* BookmarkListCollectionViewCell.swift in Sources */,
 				C0903CFF2AAAD7E00014786F /* APIService.swift in Sources */,
 				F41A97A12A5D4F2500DFF9F3 /* CurriculumTableViewHeaderView.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		4A8980CE2A617F7100746C58 /* CollectionHeaderViewRegisterDequeueProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8980CD2A617F7100746C58 /* CollectionHeaderViewRegisterDequeueProtocol.swift */; };
 		4A8980D02A61850500746C58 /* MyPageAppSettingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8980CF2A61850500746C58 /* MyPageAppSettingCollectionViewCell.swift */; };
 		4AD216402A69AC1E00C9F2F2 /* MyPageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD2163F2A69AC1E00C9F2F2 /* MyPageResponse.swift */; };
+		4AD6A34C2AB1AB6700977224 /* BookmarkAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD6A34B2AB1AB6700977224 /* BookmarkAPI.swift */; };
+		4AD6A34E2AB1F92B00977224 /* BookmarkServiceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD6A34D2AB1F92B00977224 /* BookmarkServiceWrapper.swift */; };
 		4AD6AE1A2A68436B00A3D745 /* ArticleListByCategoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD6AE192A68436B00A3D745 /* ArticleListByCategoryResponse.swift */; };
 		4AE19A172A65864F00C1DB7E /* BookmarkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE19A162A65864F00C1DB7E /* BookmarkService.swift */; };
 		4AE19A1A2A65886100C1DB7E /* BookmarkReponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE19A192A65886100C1DB7E /* BookmarkReponse.swift */; };
@@ -231,6 +233,8 @@
 		4A8980CD2A617F7100746C58 /* CollectionHeaderViewRegisterDequeueProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionHeaderViewRegisterDequeueProtocol.swift; sourceTree = "<group>"; };
 		4A8980CF2A61850500746C58 /* MyPageAppSettingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAppSettingCollectionViewCell.swift; sourceTree = "<group>"; };
 		4AD2163F2A69AC1E00C9F2F2 /* MyPageResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageResponse.swift; sourceTree = "<group>"; };
+		4AD6A34B2AB1AB6700977224 /* BookmarkAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkAPI.swift; sourceTree = "<group>"; };
+		4AD6A34D2AB1F92B00977224 /* BookmarkServiceWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkServiceWrapper.swift; sourceTree = "<group>"; };
 		4AD6AE032A66F83E00A3D745 /* progressbar_2m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_2m.json; sourceTree = "<group>"; };
 		4AD6AE052A66F84300A3D745 /* progressbar_3m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_3m.json; sourceTree = "<group>"; };
 		4AD6AE072A66F84C00A3D745 /* progressbar_4m.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = progressbar_4m.json; sourceTree = "<group>"; };
@@ -1136,6 +1140,7 @@
 				4AE19A162A65864F00C1DB7E /* BookmarkService.swift */,
 				C06E38292A662E3700B00600 /* ArticleService.swift */,
 				B57FEE2B2AA904D800ED6299 /* AuthMyPageServiceWrapper.swift */,
+				4AD6A34D2AB1F92B00977224 /* BookmarkServiceWrapper.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1251,6 +1256,7 @@
 			children = (
 				C0903D012AAAD86A0014786F /* AuthAPI.swift */,
 				C004D4982AAD8F880087F044 /* MyPageAPI.swift */,
+				4AD6A34B2AB1AB6700977224 /* BookmarkAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1630,6 +1636,7 @@
 				C0DF03352A5A93530037F740 /* UIControl+.swift in Sources */,
 				C0F029E22A5FAE2700E0D185 /* LHOnboardingErrorLabel.swift in Sources */,
 				B57BEB702A6275F500D1727C /* ViewControllerServiceable.swift in Sources */,
+				4AD6A34C2AB1AB6700977224 /* BookmarkAPI.swift in Sources */,
 				C0DF032F2A5A92170037F740 /* NameSpace.swift in Sources */,
 				B59893192A5D41F600CE1FEB /* KingfisherService.swift in Sources */,
 				B59892EE2A5B9AF300CE1FEB /* NavigationBarLayoutManager.swift in Sources */,
@@ -1644,6 +1651,7 @@
 				C06E38232A65353F00B00600 /* LoginType.swift in Sources */,
 				B5C6A2B62A5DD5FE0021BE5E /* TitleTableViewCell.swift in Sources */,
 				C0DF03962A5B8FB10037F740 /* Palette.swift in Sources */,
+				4AD6A34E2AB1F92B00977224 /* BookmarkServiceWrapper.swift in Sources */,
 				4A3D72872A5D405C00A36189 /* BookmarkListCollectionViewCell.swift in Sources */,
 				C0903CFF2AAAD7E00014786F /* APIService.swift in Sources */,
 				F41A97A12A5D4F2500DFF9F3 /* CurriculumTableViewHeaderView.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIViewController+.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UIViewController+.swift
@@ -89,7 +89,7 @@ extension UIViewController {
 
 extension UIViewController {
     func presentArticleDetailFullScreen(articleID: Int) {
-        let articleDetailViewController = ArticleDetailViewController()
+        let articleDetailViewController = ArticleDetailViewController(serviceProtocol: BookmarkService(bookmarkAPIProtocol: BookmarkAPI(apiService: APIService())))
         articleDetailViewController.setArticleId(id: articleID)
         articleDetailViewController.isModalInPresentation = true
         articleDetailViewController.modalPresentationStyle = .fullScreen

--- a/LionHeart-iOS/LionHeart-iOS/Network/API/BookmarkAPI.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/API/BookmarkAPI.swift
@@ -42,7 +42,6 @@ extension BookmarkAPI {
         let param = model.toDictionary()
         let body = try JSONSerialization.data(withJSONObject: param)
         
-        let request = try NetworkRequest(path: "/v1/article/bookmark", httpMethod: .post, body: body).makeURLRequest(isLogined: true)
         return try NetworkRequest(path: "/v1/article/bookmark", httpMethod: .post, body: body).makeURLRequest(isLogined: true)
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Network/API/BookmarkAPI.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/API/BookmarkAPI.swift
@@ -1,0 +1,48 @@
+//
+//  BookmarkAPI.swift
+//  LionHeart-iOS
+//
+//  Created by 황찬미 on 2023/09/13.
+//
+
+import Foundation
+
+protocol BookmarkAPIProtocol {
+    func getBookmark() async throws -> BookmarkResponse?
+    func postBookmark(model: BookmarkRequest) async throws -> BookmarkResponse?
+}
+
+final class BookmarkAPI: BookmarkAPIProtocol {
+    
+    private let apiService: Requestable
+    
+    init(apiService: Requestable) {
+        self.apiService = apiService
+    }
+    
+    func getBookmark() async throws -> BookmarkResponse? {
+        let request = try makeGetBookmarkUrlRequest()
+        return try await apiService.request(request)
+    }
+    
+    func postBookmark(model: BookmarkRequest) async throws -> BookmarkResponse? {
+        let request = try makePostBookmakrUrlRequest(model: model)
+        return try await apiService.request(request)
+    }
+}
+
+
+/// url request method
+extension BookmarkAPI {
+    func makeGetBookmarkUrlRequest() throws -> URLRequest {
+        return try NetworkRequest(path: "/v1/article/bookmarks", httpMethod: .get).makeURLRequest(isLogined: true)
+    }
+    
+    func makePostBookmakrUrlRequest(model: BookmarkRequest) throws -> URLRequest {
+        let param = model.toDictionary()
+        let body = try JSONSerialization.data(withJSONObject: param)
+        
+        let request = try NetworkRequest(path: "/v1/article/bookmark", httpMethod: .post, body: body).makeURLRequest(isLogined: true)
+        return try NetworkRequest(path: "/v1/article/bookmark", httpMethod: .post, body: body).makeURLRequest(isLogined: true)
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Network/DTO/Bookmark/Response/BookmarkReponse.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/DTO/Bookmark/Response/BookmarkReponse.swift
@@ -19,3 +19,15 @@ struct ArticleSummaryDTO: DTO, Response {
     let isMarked: Bool
     let tags: [String]
 }
+
+extension BookmarkResponse {
+    func toAppData() -> BookmarkAppData {
+        return BookmarkAppData(nickName: self.babyNickname,
+                               articleSummaries: self.articleSummaries.map { ArticleSummaries(title: $0.title,
+                                                                                              articleID: $0.articleId,
+                                                                                              articleImage: $0.mainImageUrl,
+                                                                                              bookmarked: $0.isMarked,
+                                                                                              tags: $0.tags)
+        })
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Network/Services/BookmarkService.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/Services/BookmarkService.swift
@@ -35,35 +35,4 @@ final class BookmarkService: BookmarkInOutServiceProtocol, BookmarkOutProtocol {
         guard let data = try await bookmarkAPIProtocol.getBookmark() else { return BookmarkAppData(nickName: "", articleSummaries: [])}
         return data.toAppData()
     }
-    
-    /*
-     기존의 코드 : 네트워크 요청, URLSession 통신, decode, appData return을 하나의 메서드에서 실행함
-     */
-    
-//    func getBookmark() async throws -> BookmarkAppData {
-//        let urlRequest = try NetworkRequest(path: "/v1/article/bookmarks", httpMethod: .get)
-//            .makeURLRequest(isLogined: true)
-//
-//        let (data, _) = try await URLSession.shared.data(for: urlRequest)
-//
-//        let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: BookmarkResponse.self)
-//
-//        return BookmarkAppData(nickName: model?.babyNickname ?? "",
-//                               articleSummaries: model?.articleSummaries.map {
-//            ArticleSummaries(title: $0.title, articleID: $0.articleId, articleImage: $0.mainImageUrl,
-//                             bookmarked: $0.isMarked, tags: $0.tags)} ?? [])
-//    }
-    
-    
-//    func postBookmark(_ model: BookmarkRequest) async throws {
-//        let param = model.toDictionary()
-//        let body = try JSONSerialization.data(withJSONObject: param)
-//
-//        let urlRequest = try NetworkRequest(path: "/v1/article/bookmark", httpMethod: .post, body: body).makeURLRequest(isLogined: true)
-//
-//        let (data, _) = try await URLSession.shared.data(for: urlRequest)
-//        try dataDecodeAndhandleErrorCode(data: data, decodeType: String.self)
-//
-//        return
-//    }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Network/Services/BookmarkService.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/Services/BookmarkService.swift
@@ -7,33 +7,63 @@
 
 import Foundation
 
-final class BookmarkService: Serviceable {
-    static let shared = BookmarkService()
-    private init() {}
+/// 내 북마크
+protocol BookmarkInOutServiceProtocol {
+    func postBookmark(model: BookmarkRequest) async throws
+    func getBookmark() async throws -> BookmarkAppData
+}
+
+// 동뷰, 성뷰
+protocol BookmarkOutProtocol {
+    func postBookmark(model: BookmarkRequest) async throws
+}
+
+final class BookmarkService: BookmarkInOutServiceProtocol, BookmarkOutProtocol {
+    
+    private let bookmarkAPIProtocol: BookmarkAPIProtocol
+    
+    init(bookmarkAPIProtocol: BookmarkAPIProtocol) {
+        self.bookmarkAPIProtocol = bookmarkAPIProtocol
+    }
+    
+    func postBookmark(model: BookmarkRequest) async throws {
+        guard let data = try await bookmarkAPIProtocol.postBookmark(model: model) else { return }
+        print(data)
+    }
     
     func getBookmark() async throws -> BookmarkAppData {
-        let urlRequest = try NetworkRequest(path: "/v1/article/bookmarks", httpMethod: .get)
-            .makeURLRequest(isLogined: true)
-        
-        let (data, _) = try await URLSession.shared.data(for: urlRequest)
-        
-        let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: BookmarkResponse.self)
-        
-        return BookmarkAppData(nickName: model?.babyNickname ?? "",
-                               articleSummaries: model?.articleSummaries.map {
-            ArticleSummaries(title: $0.title, articleID: $0.articleId, articleImage: $0.mainImageUrl,
-                             bookmarked: $0.isMarked, tags: $0.tags)} ?? [])
+        guard let data = try await bookmarkAPIProtocol.getBookmark() else { return BookmarkAppData(nickName: "", articleSummaries: [])}
+        return data.toAppData()
     }
     
-    func postBookmark(_ model: BookmarkRequest) async throws {
-        let param = model.toDictionary()
-        let body = try JSONSerialization.data(withJSONObject: param)
-        
-        let urlRequest = try NetworkRequest(path: "/v1/article/bookmark", httpMethod: .post, body: body).makeURLRequest(isLogined: true)
-        
-        let (data, _) = try await URLSession.shared.data(for: urlRequest)
-        try dataDecodeAndhandleErrorCode(data: data, decodeType: String.self)
-        
-        return
-    }
+    /*
+     기존의 코드 : 네트워크 요청, URLSession 통신, decode, appData return을 하나의 메서드에서 실행함
+     */
+    
+//    func getBookmark() async throws -> BookmarkAppData {
+//        let urlRequest = try NetworkRequest(path: "/v1/article/bookmarks", httpMethod: .get)
+//            .makeURLRequest(isLogined: true)
+//
+//        let (data, _) = try await URLSession.shared.data(for: urlRequest)
+//
+//        let model = try dataDecodeAndhandleErrorCode(data: data, decodeType: BookmarkResponse.self)
+//
+//        return BookmarkAppData(nickName: model?.babyNickname ?? "",
+//                               articleSummaries: model?.articleSummaries.map {
+//            ArticleSummaries(title: $0.title, articleID: $0.articleId, articleImage: $0.mainImageUrl,
+//                             bookmarked: $0.isMarked, tags: $0.tags)} ?? [])
+//    }
+    
+    
+//    func postBookmark(_ model: BookmarkRequest) async throws {
+//        let param = model.toDictionary()
+//        let body = try JSONSerialization.data(withJSONObject: param)
+//
+//        let urlRequest = try NetworkRequest(path: "/v1/article/bookmark", httpMethod: .post, body: body).makeURLRequest(isLogined: true)
+//
+//        let (data, _) = try await URLSession.shared.data(for: urlRequest)
+//        try dataDecodeAndhandleErrorCode(data: data, decodeType: String.self)
+//
+//        return
+//    }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewControllers/ArticleCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleCategory/ViewControllers/ArticleCategoryViewController.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2023 ArticleCategory. All rights reserved.
 //
 
-
-
 import UIKit
 
 import SnapKit
@@ -99,7 +97,7 @@ private extension ArticleCategoryViewController {
     
     func setAddTarget() {
         navigationBar.rightFirstBarItemAction {
-            let bookmarkViewController = BookmarkViewController()
+            let bookmarkViewController = BookmarkViewController(serviceProtocol: BookmarkService(bookmarkAPIProtocol: BookmarkAPI(apiService: APIService())))
             self.navigationController?.pushViewController(bookmarkViewController, animated: true)
         }
         
@@ -136,7 +134,7 @@ extension ArticleCategoryViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let ArticleListByCategoryVC = ArticleListByCategoryViewController()
+        let ArticleListByCategoryVC = ArticleListByCategoryViewController(serviceProcotol: BookmarkService(bookmarkAPIProtocol: BookmarkAPI(apiService: APIService())))
         ArticleListByCategoryVC.categoryString = dummyCase[indexPath.item].categoryString
         self.navigationController?.pushViewController(ArticleListByCategoryVC, animated: true)
     }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleDetail/ViewControllers/ArticleDetailViewController.swift
@@ -13,6 +13,9 @@ import SnapKit
 final class ArticleDetailViewController: UIViewController {
 
     // MARK: - UI Components
+    
+    private let serviceProtocol: BookmarkOutProtocol
+    
     private lazy var navigationBar = LHNavigationBarView(type: .articleMain, viewController: self)
     
     private var progressBar = LHProgressView()
@@ -30,7 +33,17 @@ final class ArticleDetailViewController: UIViewController {
         button.isHidden = true
         return button
     }()
-
+    
+    init(serviceProtocol: BookmarkOutProtocol) {
+        self.serviceProtocol = serviceProtocol
+        /// 이 코드는 왜 있어야 하지?
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     // MARK: - Properties
 
     private var isBookMarked: Bool? {
@@ -93,7 +106,7 @@ extension ArticleDetailViewController {
         Task {
             do {
                 let bookmarkRequest = BookmarkRequest(articleId: articleId, bookmarkRequestStatus: isSelected)
-                try await BookmarkService.shared.postBookmark(bookmarkRequest)
+                try await serviceProtocol.postBookmark(model: bookmarkRequest)
 
                 isBookMarked = isSelected
             } catch {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Article/ArticleListByCategory/ViewControllers/ArticleListByCategoryViewController.swift
@@ -9,8 +9,9 @@
 import UIKit
 
 import SnapKit
-
 final class ArticleListByCategoryViewController: UIViewController {
+    
+    private let serviceProcotol: BookmarkOutProtocol
     
     var categoryString = String()
     var articleListData: [ArticleDataByWeek] = [] {
@@ -34,6 +35,16 @@ final class ArticleListByCategoryViewController: UIViewController {
         tableView.tableFooterView = footerView
         return tableView
     }()
+    
+    init(serviceProcotol: BookmarkOutProtocol) {
+        self.serviceProcotol = serviceProcotol
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -149,7 +160,7 @@ extension ArticleListByCategoryViewController: UITableViewDataSource {
 
             Task {
                 do {
-                    try await BookmarkService.shared.postBookmark(BookmarkRequest(articleId: self.articleListData[indexPath.row].articleId,
+                    try await self.serviceProcotol.postBookmark(model: BookmarkRequest(articleId: self.articleListData[indexPath.row].articleId,
                                                                                   bookmarkRequestStatus: isSelected))
                     print(self.articleListData[indexPath.row].articleId)
                     isSelected ? LHToast.show(message: "북마크에 추가되었습니다", isTabBar: true) : LHToast.show(message: "북마크에 해제되었습니다", isTabBar: true)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Challenge/ViewController/ChallengeViewController.swift
@@ -249,7 +249,7 @@ private extension ChallengeViewController {
     
     func setAddTarget() {
         navigationBar.rightFirstBarItemAction {
-            let bookmarkViewController = BookmarkViewController()
+            let bookmarkViewController = BookmarkViewController(serviceProtocol: BookmarkService(bookmarkAPIProtocol: BookmarkAPI(apiService: APIService())))
             self.navigationController?.pushViewController(bookmarkViewController, animated: true)
         }
         

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumListByWeekViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumListByWeekViewController.swift
@@ -11,6 +11,18 @@ import UIKit
 import SnapKit
 
 final class CurriculumListByWeekViewController: UIViewController {
+    
+    private let serviceProtocol: BookmarkOutProtocol
+    
+    init(serviceProtocol: BookmarkOutProtocol) {
+        self.serviceProtocol = serviceProtocol
+        /// 이 코드는 왜 있어야 하지?
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     private let pregnancy = 37
     
@@ -166,9 +178,10 @@ private extension CurriculumListByWeekViewController {
                 
                 print(indexPath)
                 print(buttonSelected)
-                try await BookmarkService.shared.postBookmark(
-                    BookmarkRequest(articleId: listByWeekDatas.articleData[indexPath].articleId,
-                                    bookmarkRequestStatus: buttonSelected))
+                
+                try await
+                serviceProtocol.postBookmark(model: BookmarkRequest(articleId: listByWeekDatas.articleData[indexPath].articleId,
+                                                                    bookmarkRequestStatus: buttonSelected))
                 hideLoading()
                 buttonSelected ? LHToast.show(message: "북마크가 추가되었습니다", isTabBar: true) : LHToast.show(message: "북마크가 해제되었습니다", isTabBar: true)
             } catch {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Curriculum/ViewControllers/CurriculumViewController.swift
@@ -166,7 +166,7 @@ private extension CurriculumViewController {
     
     func setAddTarget() {
         navigationBar.rightFirstBarItemAction {
-            let bookmarkViewController = BookmarkViewController()
+            let bookmarkViewController = BookmarkViewController(serviceProtocol: BookmarkService(bookmarkAPIProtocol: BookmarkAPI(apiService: APIService())))
             self.navigationController?.pushViewController(bookmarkViewController, animated: true)
         }
         
@@ -268,7 +268,7 @@ extension CurriculumViewController: UITableViewDataSource {
             
         }
         
-        let listByWeekVC = CurriculumListByWeekViewController()
+        let listByWeekVC = CurriculumListByWeekViewController(serviceProtocol: BookmarkService(bookmarkAPIProtocol: BookmarkAPI(apiService: APIService())))
         listByWeekVC.weekToIndexPathItem = (indexPath.section * 4) + indexPath.row
         self.navigationController?.pushViewController(listByWeekVC, animated: true)
         

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/Today/ViewControllers/TodayViewController.swift
@@ -125,7 +125,7 @@ private extension TodayViewController {
 
     func setButtonAction() {
         todayNavigationBar.rightFirstBarItemAction {
-            let bookmarkViewController = BookmarkViewController()
+            let bookmarkViewController = BookmarkViewController(serviceProtocol: BookmarkService(bookmarkAPIProtocol: BookmarkAPI(apiService: APIService())))
             self.navigationController?.pushViewController(bookmarkViewController, animated: true)
         }
         


### PR DESCRIPTION
## [#100] FEAT : 로그인 구현

## 🌱 작업한 내용

- 북마크 네트워크 레이어 분리했어요.
- 현재 북마크를 보여 주는 뷰에서는 북마크 데이터를 가져오는 get, 북마크 상태값을 보내는 post API를 호출하고, 동뷰 성뷰에서는 북마크 상태값을 보내는 post API만 호출하기 때문에 protocol을 크게 두 개로 나누었어요.

```swift 내 북마크
protocol BookmarkInOutServiceProtocol {
    func postBookmark(model: BookmarkRequest) async throws
    func getBookmark() async throws -> BookmarkAppData
}

// 동뷰, 성뷰
protocol BookmarkOutProtocol {
    func postBookmark(model: BookmarkRequest) async throws
}
```

처음에는 이름만 다른 프로토콜이 여러 개가 생성되는 것 같아서 이런 식으로 분리를 했는데, 의존성 주입을 하다 보니 네이밍이 자연스럽지 않다는 생각이 들었어요.

```swift
let ArticleListByCategoryVC = ArticleListByCategoryViewController(serviceProcotol: BookmarkService(bookmarkAPIProtocol: BookmarkAPI(apiService: APIService())))
```

아티클 VC에 bookmarkservice, bookmark api 객체를 주입하는 게 어색할 수 있다는 생각이 들었어요.
그런데 현재 특정 뷰에서만 리팩토링이 진행되었기 때문에, 각각의 VC별로 프로토콜을 생성하면 해결될 것 같다는 결론이 나왔습니다.

## 🌱 PR Point
- 현재 북마크 post API 호출시 decode error를 던집니다. API 자체에는 문제가 없는데, 뷰컨을 다시 초기화하지 않으면 UI가 변경되지 않는 이슈가 있습니다. 리팩하는 과정에서 response 형식이 틀렸나 확인해 보고 싶었는데 현재 스웨거가 동작하지 않아서 일단 해결하지 못하고 PR 올렸습니다. 참고해 주세요.

## 📮 관련 이슈

- Resolved: #129
