### PR TITLE
[Refactor] #135 - 북마크 & 마이페이지 헤더뷰, 셀 디자인시스템 적용

### DIFF
--- a/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
+++ b/LionHeart-iOS/LionHeart-iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4A2050152A5DCD1900C7AF3C /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2050142A5DCD1900C7AF3C /* UICollectionView+.swift */; };
 		4A3D72872A5D405C00A36189 /* BookmarkListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3D72862A5D405C00A36189 /* BookmarkListCollectionViewCell.swift */; };
+		4A81C2912ACC7DC80056E815 /* UICollectionViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A81C2902ACC7DC80056E815 /* UICollectionViewCell+.swift */; };
 		4A860AD62A6265B2002BA428 /* BookmarkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A860AD52A6265B2002BA428 /* BookmarkModel.swift */; };
 		4A8980C52A611EE200746C58 /* MyPageProfileCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8980C42A611EE200746C58 /* MyPageProfileCollectionViewCell.swift */; };
 		4A8980C72A6146DA00746C58 /* MyPageCustomerServiceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8980C62A6146D900746C58 /* MyPageCustomerServiceCollectionViewCell.swift */; };
@@ -236,6 +237,7 @@
 /* Begin PBXFileReference section */
 		4A2050142A5DCD1900C7AF3C /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
 		4A3D72862A5D405C00A36189 /* BookmarkListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkListCollectionViewCell.swift; sourceTree = "<group>"; };
+		4A81C2902ACC7DC80056E815 /* UICollectionViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+.swift"; sourceTree = "<group>"; };
 		4A860AD52A6265B2002BA428 /* BookmarkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkModel.swift; sourceTree = "<group>"; };
 		4A8980C12A5FD6AF00746C58 /* BookmarkDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkDetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A8980C42A611EE200746C58 /* MyPageProfileCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageProfileCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -724,6 +726,7 @@
 				C00780B62A5FFE0E0043EB36 /* UILabel+.swift */,
 				4A2050142A5DCD1900C7AF3C /* UICollectionView+.swift */,
 				D34280762A66B90C00DA1499 /* UILabelPadding.swift */,
+				4A81C2902ACC7DC80056E815 /* UICollectionViewCell+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1675,6 +1678,7 @@
 				C0F029C72A5EFB9D00E0D185 /* LHProgressView.swift in Sources */,
 				B5C6A2BA2A5DE14E0021BE5E /* ChapterTitleTableViewCell.swift in Sources */,
 				C0DF034D2A5A9B8D0037F740 /* (null) in Sources */,
+				4A81C2912ACC7DC80056E815 /* UICollectionViewCell+.swift in Sources */,
 				C0856B772ABFC4EA0026D9F8 /* MyPageServiceImpl.swift in Sources */,
 				C0DF03982A5B90790037F740 /* UIColor+.swift in Sources */,
 				C0F029E02A5FAD1200E0D185 /* LHOnboardingDescriptionLabel.swift in Sources */,

--- a/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UICollectionViewCell+.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Extensions/UICollectionViewCell+.swift
@@ -1,0 +1,15 @@
+//
+//  UICollectionViewCell+.swift
+//  LionHeart-iOS
+//
+//  Created by 황찬미 on 2023/10/04.
+//
+
+import UIKit
+
+extension UICollectionViewCell {
+    func getIndexPath() -> IndexPath? {
+        guard let superView = self.superview as? UICollectionView else { return nil }
+        return superView.indexPath(for: self)
+    }
+}

--- a/LionHeart-iOS/LionHeart-iOS/Global/Protocols/CollectionHeaderViewRegisterDequeueProtocol.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Protocols/CollectionHeaderViewRegisterDequeueProtocol.swift
@@ -8,13 +8,13 @@
 import UIKit
 
 protocol CollectionSectionViewRegisterDequeueProtocol where Self: UICollectionReusableView {
-    associatedtype T: AppData
+//    associatedtype T: AppData
     static func registerHeaderView(to collectionView: UICollectionView)
     static func registerFooterView(to collectionView: UICollectionView)
     static func dequeueReusableheaderView(to collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, indexPath: IndexPath) -> Self
     static func dequeueReusablefooterView(to collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, indexPath: IndexPath) -> Self
     static var reuseIdentifier: String { get }
-    var inputData: T? { get set }
+//    var inputData: T? { get set }
 }
 
 extension CollectionSectionViewRegisterDequeueProtocol {

--- a/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHImageButton.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHImageButton.swift
@@ -13,6 +13,11 @@ final class LHImageButton: UIButton {
         self.setImage(setImage, for: .normal)
     }
     
+    func priorty(_ priority: UILayoutPriority, _ axis: NSLayoutConstraint.Axis) -> Self {
+        self.setContentHuggingPriority(priority, for: axis)
+        return self
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHLabel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/UIComponents/LHLabel.swift
@@ -24,6 +24,11 @@ final class LHLabel: UILabel {
         self.numberOfLines = lines
     }
     
+    func priorty(_ priority: UILayoutPriority, _ axis: NSLayoutConstraint.Axis) -> Self {
+        self.setContentHuggingPriority(priority, for: axis)
+        return self
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/LionHeart-iOS/LionHeart-iOS/Global/Utils/Palette.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Global/Utils/Palette.swift
@@ -22,7 +22,7 @@ enum Palette: String {
     case gray1000 = "Gray1000"
     case lionRed = "LionRed"
     case componentLionRed = "ComponentLionRed"
-    case background = "background"
+    case background = "Background"
     case kakao = "KakaoYellow"
     case clear = "clear"
 }

--- a/LionHeart-iOS/LionHeart-iOS/Network/Manager/MyPageManagerImpl.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Network/Manager/MyPageManagerImpl.swift
@@ -17,9 +17,9 @@ final class MyPageManagerImpl: MyPageManager {
         self.authService = authService
     }
     
-    func getMyPage() async throws -> MyPageAppData {
+    func getMyPage() async throws -> BadgeProfileAppData {
         guard let model = try await mypageService.getMyPage() else { throw NetworkError.badCasting }
-        return MyPageAppData(badgeImage: model.level, nickname: model.babyNickname, isAlarm: model.notificationStatus)
+        return BadgeProfileAppData(badgeImage: model.level, nickname: model.babyNickname, isAlarm: model.notificationStatus)
     }
     
     func resignUser() async throws {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/Cells/BookmarkDetailCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/Cells/BookmarkDetailCollectionViewCell.swift
@@ -12,17 +12,7 @@ import SnapKit
 
 final class BookmarkDetailCollectionViewCell: UICollectionViewCell, CollectionViewCellRegisterDequeueProtocol {
     
-    private let bookmarkDetailLabel: UILabel = {
-        let label = UILabel()
-        label.text = """
-                     사랑이 아빠님이
-                     보관한 아티클이에요
-                     """
-        label.numberOfLines = 2
-        label.font = .pretendard(.head3)
-        label.textColor = .designSystem(.white)
-        return label
-    }()
+    private let bookmarkDetailLabel = LHLabel(type: .head3, color: .white, lines: 2)
     
     var inputData: BookmarkAppData? {
         didSet {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/Cells/BookmarkListCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/Cells/BookmarkListCollectionViewCell.swift
@@ -10,12 +10,17 @@ import UIKit
 
 import SnapKit
 
+private enum Size {
+    static let widthHeightRatio: CGFloat = 80/125
+}
+
 final class BookmarkListCollectionViewCell: UICollectionViewCell,
                                         CollectionViewCellRegisterDequeueProtocol {
-    
-    private enum Size {
-        static let widthHeightRatio: CGFloat = 80/125
-    }
+    private let articleImageView = LHImageView(contentMode: .scaleToFill)
+    private let articleTitleLabel = LHLabel(type: .title2, color: .white, lines: 2).priorty(.defaultLow, .horizontal)
+    private let tagLabel = LHLabel(type: .body4, color: .gray400).priorty(.defaultLow, .horizontal)
+    private lazy var bookmarkButton = LHImageButton(setImage: .assetImage(.bookmarkActiveSmall)).priorty(.defaultHigh, .horizontal)
+    private let bottomLineView = LHUnderLine(lineColor: .gray800)
     
     var bookmarkButtonClosure: ((IndexPath) -> Void)?
     
@@ -32,55 +37,13 @@ final class BookmarkListCollectionViewCell: UICollectionViewCell,
             tagLabel.text =  inputData.tags.joined(separator: " · ")
         }
     }
-    
-    private let articleImageView: UIImageView = {
-        let imageView = UIImageView()
-        return imageView
-    }()
-    
-    private let articleTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "제목입니다 출산카드 신청하기 A to Z"
-        label.numberOfLines = 2
-        label.lineBreakMode = .byWordWrapping
-        label.font = .pretendard(.title2)
-        label.textColor = .designSystem(.white)
-        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        return label
-    }()
-    
-    private let tagLabel: UILabel = {
-        let label = UILabel()
-        label.text = "신체 변화 ⋅ 건강 ⋅ 아무튼 태그"
-        label.font = .pretendard(.body4)
-        label.textColor = .designSystem(.gray400)
-        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        return label
-    }()
-    
-    private lazy var bookmarkButton: UIButton = {
-        let button = UIButton()
-        button.setImage(.assetImage(.bookmarkActiveSmall), for: .normal)
-        button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        button.addButtonAction { [weak self] _ in
-            guard let self else { return }
-            guard let indexPath = getIndexPath() else { return }
-            self.bookmarkButtonClosure?(indexPath)
-        }
-        return button
-    }()
-    
-    private let bottomLineView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .designSystem(.gray800)
-        return view
-    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         setHierarchy()
         setLayout()
+        setButtonAction()
     }
     
     @available(*, unavailable)
@@ -120,6 +83,13 @@ private extension BookmarkListCollectionViewCell {
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
             $0.height.equalTo(1)
+        }
+    }
+    
+    func setButtonAction() {
+        bookmarkButton.addButtonAction { _ in
+            guard let indexPath = self.getIndexPath() else { return }
+            self.bookmarkButtonClosure?(indexPath)
         }
     }
     

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/Cells/BookmarkListCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/Cells/BookmarkListCollectionViewCell.swift
@@ -92,9 +92,4 @@ private extension BookmarkListCollectionViewCell {
             self.bookmarkButtonClosure?(indexPath)
         }
     }
-    
-    func getIndexPath() -> IndexPath? {
-        guard let superView = self.superview as? UICollectionView else { return nil }
-        return superView.indexPath(for: self)
-    }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/BookMark/ViewControllers/BookmarkViewController.swift
@@ -19,17 +19,11 @@ final class BookmarkViewController: UIViewController {
     
     private let manager: BookmarkManger
     
+    private lazy var navigationBar = LHNavigationBarView(type: .bookmark, viewController: self)
+    private lazy var bookmarkCollectionView = LHCollectionView()
+    
     private var bookmarkAppData = BookmarkAppData(nickName: "", articleSummaries: [ArticleSummaries]())
     private var bookmarkList = [ArticleSummaries]()
-    
-    private lazy var navigationBar = LHNavigationBarView(type: .bookmark, viewController: self)
-    
-    private lazy var bookmarkCollectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-        collectionView.backgroundColor = .designSystem(.background)
-        collectionView.showsVerticalScrollIndicator = false
-        return collectionView
-    }()
     
     init(manager: BookmarkManger) {
         self.manager = manager
@@ -53,6 +47,7 @@ final class BookmarkViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         showLoading()
+        
         Task {
             do {
                 self.bookmarkAppData = try await manager.getBookmark()

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageAppSettingCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageAppSettingCollectionViewCell.swift
@@ -6,6 +6,11 @@
 //  Copyright (c) 2023 MyPageAppSetting. All rights reserved.
 //
 
+enum CellType: String {
+    case alaram = "알림 설정"
+    case version = "앱 버전"
+}
+
 import UIKit
 
 import SnapKit
@@ -39,9 +44,16 @@ final class MyPageAppSettingCollectionViewCell: UICollectionViewCell, Collection
         return view
     }()
     
-    var inputData: MyPageAppSettinLocalgData? {
+    var inputData: String? {
         didSet {
-            configureData(inputData)
+            guard let inputData = inputData else { return }
+            settingLabel.text = inputData
+            
+            if CellType.alaram == CellType(rawValue: inputData) {
+                versionLabel.isHidden = true
+            } else {
+                alarmSwtich.isHidden = true
+            }
         }
     }
 
@@ -50,8 +62,6 @@ final class MyPageAppSettingCollectionViewCell: UICollectionViewCell, Collection
         
         setHierarchy()
         setLayout()
-        setAddTarget()
-        setDelegate()
     }
     
     @available(*, unavailable)
@@ -85,20 +95,5 @@ private extension MyPageAppSettingCollectionViewCell {
             $0.leading.trailing.bottom.equalToSuperview()
             $0.height.equalTo(1)
         }
-    }
-    
-    func setAddTarget() {
-        
-    }
-    
-    func setDelegate() {
-        
-    }
-    
-    func configureData(_ model: MyPageAppSettinLocalgData?) {
-        guard let model = model else { return }
-        settingLabel.text = model.appSettingtext
-        alarmSwtich.isHidden = !model.showSwitch
-        versionLabel.isHidden = model.showSwitch
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageAppSettingCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageAppSettingCollectionViewCell.swift
@@ -17,32 +17,9 @@ import SnapKit
 
 final class MyPageAppSettingCollectionViewCell: UICollectionViewCell, CollectionViewCellRegisterDequeueProtocol {
     
-    private let settingLabel = {
-        let label = UILabel()
-        label.font = .pretendard(.body2M)
-        label.textColor = .designSystem(.white)
-        return label
-    }()
-    
-    private let alarmSwtich = {
-        let switchButton = UISwitch()
-        switchButton.isOn = false
-        return switchButton
-    }()
-    
-    private let versionLabel = {
-        let label = UILabel()
-        label.text = "1.0.0"
-        label.font = .pretendard(.body3R)
-        label.textColor = .designSystem(.gray500)
-        return label
-    }()
-    
-    private let bottomView = {
-        let view = UIView()
-        view.backgroundColor = .designSystem(.gray800)
-        return view
-    }()
+    private let settingLabel = LHLabel(type: .body2M, color: .white)
+    private let versionLabel = LHLabel(type: .body3R, color: .gray500)
+    private let bottomView = LHUnderLine(lineColor: .gray800)
     
     var inputData: String? {
         didSet {
@@ -51,8 +28,6 @@ final class MyPageAppSettingCollectionViewCell: UICollectionViewCell, Collection
             
             if CellType.alaram == CellType(rawValue: inputData) {
                 versionLabel.isHidden = true
-            } else {
-                alarmSwtich.isHidden = true
             }
         }
     }
@@ -72,17 +47,12 @@ final class MyPageAppSettingCollectionViewCell: UICollectionViewCell, Collection
 
 private extension MyPageAppSettingCollectionViewCell {
     func setHierarchy() {
-        addSubviews(settingLabel, alarmSwtich, versionLabel, bottomView)
+        addSubviews(settingLabel, versionLabel, bottomView)
     }
     
     func setLayout() {
         settingLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(20)
-            $0.centerY.equalToSuperview()
-        }
-        
-        alarmSwtich.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
         }
         

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageCustomerServiceCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageCustomerServiceCollectionViewCell.swift
@@ -16,9 +16,9 @@ final class MyPageCustomerServiceCollectionViewCell: UICollectionViewCell, Colle
     private lazy var nextButton = LHImageButton(setImage: ImageLiterals.Curriculum.arrowRightSmall)
     private let bottomView = LHView(color: .designSystem(.gray800))
     
-    var inputData: MyPageLocalData? {
+    var inputData: String? {
         didSet {
-            configureData(inputData)
+            listNameLabel.text = inputData
         }
     }
 
@@ -62,10 +62,5 @@ private extension MyPageCustomerServiceCollectionViewCell {
         nextButton.addButtonAction { _ in
             print("눌리냐")
         }
-    }
-    
-    func configureData(_ model: MyPageLocalData?) {
-        guard let model = model else { return }
-        listNameLabel.text =  model.titleLabel
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageProfileCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageProfileCollectionViewCell.swift
@@ -48,7 +48,7 @@ final class MyPageProfileCollectionViewCell: UICollectionViewCell, CollectionVie
         return button
     }()
     
-    var inputData: MyPageAppData? {
+    var inputData: BadgeProfileAppData? {
         didSet {
             guard let inputData else { return }
             

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageProfileCollectionViewCell.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Cells/MyPageProfileCollectionViewCell.swift
@@ -16,19 +16,8 @@ final class MyPageProfileCollectionViewCell: UICollectionViewCell, CollectionVie
         static let buttonMutipleSize: CGFloat = 40/320
     }
     
-    private let badgeImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        return imageView
-    }()
-    
-    private let profileLabel = {
-        let label = UILabel()
-        label.numberOfLines = 0
-        label.font = .pretendard(.head3)
-        label.textColor = .designSystem(.white)
-        return label
-    }()
+    private let badgeImageView = LHImageView(contentMode: .scaleAspectFit)
+    private let profileLabel = LHLabel(type: .head3, color: .white, lines: 0)
     
     private lazy var profileEditButton = {
         var titleAttr = AttributedString.init("정보 수정")

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Model/MyPageModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Model/MyPageModel.swift
@@ -9,29 +9,39 @@ import Foundation
 
 // MARK: DummyData
 
-struct MyPageAppData: AppData {
+enum MyPageSection {
+    case badgeSection(section: MyPageSectionModel)
+    case customerServiceSetion(section: MyPageSectionModel)
+    case appSettingSection(section: MyPageSectionModel)
+    
+    static let sectionArray: [MyPageSection] = [.badgeSection(section: MyPageSectionModel(sectionTitle: "",
+                                                                                         cellTitle: [""])),
+                                               .customerServiceSetion(section: MyPageSectionModel(sectionTitle: "고객센터",
+                                                                                                  cellTitle: ["공지사항","FAQ", "1:1 문의", "서비스 피드백", "이용약관", "개인보호 정책"])),
+                                               .appSettingSection(section: MyPageSectionModel(sectionTitle: "앱 설정",
+                                                                                              cellTitle: ["알림 설정", "앱 버전"]))]
+}
+
+struct badgeProfileSection { }
+
+struct MyPageSectionModel {
+    let sectionTitle: String
+    let cellTitle: [String]
+}
+
+// MARK: BadgeProfileAppData
+
+struct BadgeProfileAppData: AppData {
     let badgeImage: String
     let nickname: String
     let isAlarm: String
 }
 
-extension MyPageAppData {
+extension BadgeProfileAppData {
     static let empty: Self = .init(badgeImage: "", nickname: "", isAlarm: "")
 }
 
 // MARK: LocalData
-
-struct MyPageLocalData: AppData {
-    let titleLabel: String
-}
-
-extension MyPageLocalData {
-    static let myPageServiceLabelList = [MyPageLocalData(titleLabel: "공지사항"), MyPageLocalData(titleLabel: "FAQ"),
-                                         MyPageLocalData(titleLabel: "1:1 문의"), MyPageLocalData(titleLabel: "서비스 피드백"),
-                                         MyPageLocalData(titleLabel: "이용약관"), MyPageLocalData(titleLabel: "개인보호 정책")]
-    
-    static let myPageSectionLabelList = [MyPageLocalData(titleLabel: "고객센터"), MyPageLocalData(titleLabel: "앱 설정")]
-}
 
 struct MyPageAppSettinLocalgData: AppData {
     var appSettingtext: String

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Model/MyPageModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Model/MyPageModel.swift
@@ -22,8 +22,6 @@ enum MyPageSection {
                                                                                               cellTitle: ["알림 설정", "앱 버전"]))]
 }
 
-struct badgeProfileSection { }
-
 struct MyPageSectionModel {
     let sectionTitle: String
     let cellTitle: [String]
@@ -39,15 +37,4 @@ struct BadgeProfileAppData: AppData {
 
 extension BadgeProfileAppData {
     static let empty: Self = .init(badgeImage: "", nickname: "", isAlarm: "")
-}
-
-// MARK: LocalData
-
-struct MyPageAppSettinLocalgData: AppData {
-    var appSettingtext: String
-    var showSwitch: Bool
-}
-
-extension MyPageAppSettinLocalgData {
-    static let myPageAppSettingDataList = [MyPageAppSettinLocalgData(appSettingtext: "알림 설정", showSwitch: true), MyPageAppSettinLocalgData(appSettingtext: "앱 버전", showSwitch: false)]
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Model/MyPageModel.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Model/MyPageModel.swift
@@ -10,12 +10,11 @@ import Foundation
 // MARK: DummyData
 
 enum MyPageSection {
-    case badgeSection(section: MyPageSectionModel)
+    case badgeSection
     case customerServiceSetion(section: MyPageSectionModel)
     case appSettingSection(section: MyPageSectionModel)
     
-    static let sectionArray: [MyPageSection] = [.badgeSection(section: MyPageSectionModel(sectionTitle: "",
-                                                                                         cellTitle: [""])),
+    static let sectionArray: [MyPageSection] = [.badgeSection,
                                                .customerServiceSetion(section: MyPageSectionModel(sectionTitle: "고객센터",
                                                                                                   cellTitle: ["공지사항","FAQ", "1:1 문의", "서비스 피드백", "이용약관", "개인보호 정책"])),
                                                .appSettingSection(section: MyPageSectionModel(sectionTitle: "앱 설정",

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
@@ -57,23 +57,6 @@ final class MyPageViewController: UIViewController {
         registerCell()
         hiddenNavigationBar()
         setTabbar()
-        
-//        for section in sections {
-//            switch section {
-//            case .badgeSection(let section):
-//                sections.append(.badgeSection(section: section))
-//            case .customerServiceSetion(let section):
-//                sections.append(.customerServiceSetion(section: section))
-//            case .appSettingSection(let section):
-//                sections.append(.appSettingSection(section: section))
-//            }
-//        }
-        
-        
-        
-//        sections.append(.badgeSection(section: MyPageSectionModel(sectionTitle: "", cellTitle: [""])))
-//        sections.append(.customerServiceSetion(section: MyPageSectionModel(sectionTitle: "고객센터", cellTitle: ["공지사항", "FAQ", "1:1 문의", "서비스 피드백", "이용약관", "개인보호 정책"])))
-//        sections.append(.appSettingSection(section: MyPageSectionModel(sectionTitle: "앱 설정", cellTitle: ["알림 설정", "앱 버전"])))
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Views/MyPageHeaderView.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Views/MyPageHeaderView.swift
@@ -42,7 +42,7 @@ final class MyPageHeaderView: UICollectionReusableView, CollectionSectionViewReg
 private extension MyPageHeaderView {
     
     func setUI() {
-        backgroundColor = .clear
+        backgroundColor = .designSystem(.background)
     }
     func setHierarchy() {
         addSubview(sectionTitleLabel)

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Views/MyPageHeaderView.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Views/MyPageHeaderView.swift
@@ -18,9 +18,9 @@ final class MyPageHeaderView: UICollectionReusableView, CollectionSectionViewReg
         return label
     }()
     
-    var inputData: MyPageLocalData? {
+    var inputData: String? {
         didSet {
-            configureData(inputData)
+            sectionTitleLabel.text = inputData
         }
     }
     
@@ -52,10 +52,5 @@ private extension MyPageHeaderView {
         sectionTitleLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(20)
         }
-    }
-    
-    func configureData(_ model: MyPageLocalData?) {
-        guard let model = model else { return }
-        sectionTitleLabel.text = model.titleLabel
     }
 }

--- a/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Views/MyPageHeaderView.swift
+++ b/LionHeart-iOS/LionHeart-iOS/Scenes/MyPage/Views/MyPageHeaderView.swift
@@ -11,12 +11,7 @@ import SnapKit
 
 final class MyPageHeaderView: UICollectionReusableView, CollectionSectionViewRegisterDequeueProtocol {
     
-    private let sectionTitleLabel = {
-        let label = UILabel()
-        label.font = .pretendard(.body3R)
-        label.textColor = .designSystem(.gray500)
-        return label
-    }()
+    private let sectionTitleLabel = LHLabel(type: .body3R, color: .gray500)
     
     var inputData: String? {
         didSet {


### PR DESCRIPTION
## [Refactor] #135 - 북마크 & 마이페이지 헤더뷰, 셀 디자인시스템 적용

## 🌱 작업한 내용

- 북마크 디자인시스템 적용했어요.
- 마이페이지 VC는 의성 오빠가 디자인시스템 적용해 놓은 것 확인했고, 각각의 cell, headerView에도 디자인시스템 적용했어요.
- 마이페이지가 배지 프로필, 고객센터, 알림 세팅 총 세 개의 섹션으로 나뉘어져 있는데, 각각의 케이스를 enum으로 나누어서 구분했어요.
의성 오빠가 예전에 해 준 코드리뷰인데... https://github.com/gosopt-LionHeart/LionHeart-iOS/pull/51
> 연관값은 그 케이스에 연관되어있는 데이터를 가져온거니까 확인하면서 데이터를 가져올 필요도 없구요!

결국 현재 제가 enum으로 처리한 데이터가 더미이기 때문에, 이 의도가 제대로 반영이 됐는지는 모르겠네요 ㅠ__ㅠ


```swift
enum MyPageSection {
    case badgeSection
    case customerServiceSetion(section: MyPageSectionModel)
    case appSettingSection(section: MyPageSectionModel)
    
    static let sectionArray: [MyPageSection] = [.badgeSection,
                                               .customerServiceSetion(section: MyPageSectionModel(sectionTitle: "고객센터",
                                                                                                  cellTitle: ["공지사항","FAQ", "1:1 문의", "서비스 피드백", "이용약관", "개인보호 정책"])),
                                               .appSettingSection(section: MyPageSectionModel(sectionTitle: "앱 설정",
                                                                                              cellTitle: ["알림 설정", "앱 버전"]))]
}
```

해당 cell들에 뿌려질 데이터들이 더미 데이터들이기 때문에, 배열을 생성해 주었어요.

```swift
    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
        switch sections[section] {
        case .badgeSection:
            return 1
        case .customerServiceSetion(let sectionArray):
            return sectionArray.cellTitle.count
        case .appSettingSection(let sectionArray):
            return sectionArray.cellTitle.count
        }
    }
````
VC에서 연관값으로 해당 case에 맞는 데이터를 넣어 주도록 구현했습니다.

- 북마크 뷰에는 라벨과 버튼들 사이에 레이아웃 우선순위가 필요해서 LHButton 디자인시스템, LHLabel에도 동일하게 priority를 추가했습니다.
```swift
final class LHImageButton: UIButton {
    init(setImage: UIImage?) {
        super.init(frame: .zero)
        self.setImage(setImage, for: .normal)
    }
    
    func priorty(_ priority: UILayoutPriority, _ axis: NSLayoutConstraint.Axis) -> Self {
        self.setContentHuggingPriority(priority, for: axis)
        return self
    }
    
    required init?(coder: NSCoder) {
        fatalError("init(coder:) has not been implemented")
    }
}
```

- 북마크 collectionView cell에서 superView에 접근해 해당 indexPath.item 값을 return 해 주는 메서드는 extension 파일로 옮겼습니다.
```swift
extension UICollectionViewCell {
    func getIndexPath() -> IndexPath? {
        guard let superView = self.superview as? UICollectionView else { return nil }
        return superView.indexPath(for: self)
    }
}
```
CollectionViewCellRegisterDequeueProtocol 프로토콜에 추가할까 고민했었는데, 모든 collectionViewCell이 상위뷰에게 indexPath 값을 넘겨 줘야 하지 않는다고 판단되어서, extension으로 따로 뺐습니당.


## 📮 관련 이슈

- Resolved: #135
